### PR TITLE
Feature/front/tile

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -8,7 +8,9 @@ class AnnotationsController < ApplicationController
 
     render json: {
       id: annotation.id,
-      katagami_url: ant_params[:katagami].presigned_url
+      katagami_url: ant_params[:katagami].presigned_url,
+      katagami_width: ant_params[:katagami].width,
+      katagami_height: ant_params[:katagami].height
     }
   end
 end

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -1,0 +1,5 @@
+class LabelsController < ApplicationController
+  def index
+    render json: Label.all
+  end
+end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,3 @@
+class Label < ApplicationRecord
+  validates :name, presence: true, allow_nil: false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,10 @@ Rails.application.routes.draw do
   post '/signup', to: 'users#signup'
   post '/login' , to: 'users#login'
   get 'users/:id', to: 'users#show'
-
-  #Katagami
+  # Katagami
   get '/katagamis', to: 'katagamis#index'
-
-  #Annotation
+  # Annotation
   post '/annotations/:katagami_id/:user_id', to: 'annotations#create'
+  # Label
+  get '/labels', to: 'labels#index'
 end

--- a/db/migrate/20191203095121_create_labels.rb
+++ b/db/migrate/20191203095121_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :labels do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_03_085108) do
+ActiveRecord::Schema.define(version: 2019_12_03_095121) do
 
   create_table "annotations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "katagami_id"
-    t.integer "status", default: 0
+    t.bigint "user_id", null: false
+    t.bigint "katagami_id", null: false
+    t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["katagami_id"], name: "index_annotations_on_katagami_id"
@@ -30,6 +30,12 @@ ActiveRecord::Schema.define(version: 2019_12_03_085108) do
     t.datetime "updated_at", null: false
     t.string "cw_obj", null: false
     t.string "name", null: false
+  end
+
+  create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,15 @@ Katagami.transaction do
     katagami.save!
   end
 end
+
+label_names = [
+  'kasuri',   'kiku', 'ume',   'hishi',     'sakura',
+  'karakusa', 'chou', 'matsu', 'kamenokou', 'asanoha'
+]
+
+Label.transaction do
+  label_names.each do |name|
+    label = Label.new(name: name)
+    label.save!
+  end
+end

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -52,7 +52,7 @@ export default function () {
   }
 
   const PrivateRoute = ({ path, component }) => {
-    console.log(path);
+    // console.log(path);
     return (
       isLoggedIn ? (
         <Route path={path} component={component}/>

--- a/front/src/components/lv1/Tile.js
+++ b/front/src/components/lv1/Tile.js
@@ -15,11 +15,6 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center'
   },
   selected: {
-    color: grey[50],
-    border: '2px solid',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
     backgroundColor: 'rgba(205, 220, 57, 0.8)'
   }
 }));
@@ -37,7 +32,11 @@ export default function (props) {
     <Grid
       item
       xs={12 / square}
-      className={isSelected ? classes.selected : classes.tile}
+      className={
+        isSelected
+          ? classes.tile + ' ' + classes.selected
+          : classes.tile
+      }
       onClick={() => handleToggleTile(number)}
     />
   );

--- a/front/src/components/lv1/Tile.js
+++ b/front/src/components/lv1/Tile.js
@@ -1,8 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { makeStyles } from '@material-ui/styles';
-import Container from 'components/lv1/Container';
 import { Grid } from '@material-ui/core';
-import { pink, grey, lime } from '@material-ui/core/colors';
+import { grey } from '@material-ui/core/colors';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -21,7 +20,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'rgba(97, 97, 97, 0.7)'
+    backgroundColor: 'rgba(205, 220, 57, 0.8)'
   }
 }));
 
@@ -29,23 +28,17 @@ export default function (props) {
   const {
     number,
     square,
+    isSelected,
     handleToggleTile
   } = props;
-  const [isSelected, setIsSelected] = useState(false);
-  let color = '';
   const classes = useStyles();
-
-  const handleToggle = () => {
-    setIsSelected(!isSelected);
-    // handleToggleTile(number);
-  }
 
   return (
     <Grid
       item
       xs={12 / square}
       className={isSelected ? classes.selected : classes.tile}
-      onClick={handleToggle}
+      onClick={() => handleToggleTile(number)}
     />
   );
 }

--- a/front/src/components/lv2/KatagamiCard.js
+++ b/front/src/components/lv2/KatagamiCard.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import {
-  GridListTile,
   Card,
   CardContent,
   CardActions,

--- a/front/src/components/lv2/Tile.js
+++ b/front/src/components/lv2/Tile.js
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import { makeStyles } from '@material-ui/styles';
+import Container from 'components/lv1/Container';
+import { Grid } from '@material-ui/core';
+import { pink, grey, lime } from '@material-ui/core/colors';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    border: '1px solid'
+  },
+  tile: {
+    color: grey[50],
+    border: '2px solid',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  selected: {
+    color: grey[50],
+    border: '2px solid',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(97, 97, 97, 0.7)'
+  }
+}));
+
+export default function (props) {
+  const {
+    number,
+    square,
+    handleToggleTile
+  } = props;
+  const [isSelected, setIsSelected] = useState(false);
+  let color = '';
+  const classes = useStyles();
+
+  const handleToggle = () => {
+    setIsSelected(!isSelected);
+    // handleToggleTile(number);
+  }
+
+  return (
+    <Grid
+      item
+      xs={12 / square}
+      className={isSelected ? classes.selected : classes.tile}
+      onClick={handleToggle}
+    />
+  );
+}

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -1,27 +1,53 @@
 import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/styles';
-import Container from 'components/lv1/Container';
+import { Grid } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
+  root: {
+    width: 640
+  },
   katagami: {
-    width: '640px',
-    height: 'auto'
+    backgroundImage: props => `url(${props.katagamiUrl})`,
+    backgroundSize: 'cover',
+    width: props => `${props.fixedWidth}px`,
+    height: props => `${props.fixedHeight}px`
+  },
+  tile: {
+    height: props => `${props.tileHeight}`
   }
 }));
 
 export default function (props) {
   const {
-    katagamiUrl
+    katagamiUrl,
+    katagamiWidth,
+    katagamiHeight,
+    dividing
   } = props;
-  const classes = useStyles();
+  const fixedWidth = 640;
+  const fixedHeight = katagamiHeight / katagamiWidth * fixedWidth;
+  const tileSquare = Math.sqrt(dividing);
+  const tileHeight = fixedHeight / tileSquare;
+  const classes = useStyles({
+    katagamiUrl,
+    fixedWidth,
+    fixedHeight,
+    tileHeight
+  });
+
+  const Labels = () => {
+    const labels = [];
+    for (let i = 0; i < dividing; i++) {
+      labels.push(<Grid xs={12/tileSquare}>{i}</Grid>);
+    }
+    return labels;
+  }
 
   return (
     <div className={classes.root}>
-      <img
-        src={katagamiUrl}
-        alt={`Image ${katagamiId}`}
-        className={classes.katagami}
-      />
+      <Grid container spacing={0} className={classes.katagami}>
+        <Labels />
+      </Grid>
     </div>
   );
 }

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -13,14 +13,6 @@ const useStyles = makeStyles(theme => ({
     backgroundSize: 'cover',
     width: props => `${props.fixedWidth}px`,
     height: props => `${props.fixedHeight}px`
-  },
-  tile: {
-    color: pink[500],
-    backgroundColor:  `rgba(255, 96, 144, 0.5)`,
-    border: '1px dots',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center'
   }
 }));
 

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/styles';
 import { Grid } from '@material-ui/core';
+import { pink } from '@material-ui/core/colors';
+import Tile from 'components/lv2/Tile';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -13,7 +15,12 @@ const useStyles = makeStyles(theme => ({
     height: props => `${props.fixedHeight}px`
   },
   tile: {
-    height: props => `${props.tileHeight}`
+    color: pink[500],
+    backgroundColor:  `rgba(255, 96, 144, 0.5)`,
+    border: '1px dots',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
   }
 }));
 
@@ -36,10 +43,17 @@ export default function (props) {
     tileHeight
   });
 
-  const Labels = () => {
+  const Tiles = () => {
     const labels = [];
     for (let i = 1; i <= dividing; i++) {
-      labels.push(<Grid item xs={12/tileSquare}>{i}</Grid>);
+      labels.push(
+        <Tile
+          key={i}
+          number={i}
+          square={tileSquare}
+          handleToggleTile={handleToggleTile}
+        />
+      );
     }
     return labels;
   }
@@ -47,7 +61,7 @@ export default function (props) {
   return (
     <div className={classes.root}>
       <Grid container spacing={0} className={classes.katagami}>
-        <Labels />
+        <Tiles />
       </Grid>
     </div>
   );

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -22,7 +22,8 @@ export default function (props) {
     katagamiUrl,
     katagamiWidth,
     katagamiHeight,
-    dividing
+    dividing,
+    handleToggleTile
   } = props;
   const fixedWidth = 640;
   const fixedHeight = katagamiHeight / katagamiWidth * fixedWidth;
@@ -37,8 +38,8 @@ export default function (props) {
 
   const Labels = () => {
     const labels = [];
-    for (let i = 0; i < dividing; i++) {
-      labels.push(<Grid xs={12/tileSquare}>{i}</Grid>);
+    for (let i = 1; i <= dividing; i++) {
+      labels.push(<Grid item xs={12/tileSquare}>{i}</Grid>);
     }
     return labels;
   }

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from 'react';
+import { makeStyles } from '@material-ui/styles';
+import Container from 'components/lv1/Container';
+
+const useStyles = makeStyles(theme => ({
+  katagami: {
+    width: '640px',
+    height: 'auto'
+  }
+}));
+
+export default function (props) {
+  const {
+    katagamiUrl
+  } = props;
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <img
+        src={katagamiUrl}
+        alt={`Image ${katagamiId}`}
+        className={classes.katagami}
+      />
+    </div>
+  );
+}

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { makeStyles } from '@material-ui/styles';
 import { Grid } from '@material-ui/core';
 import { pink } from '@material-ui/core/colors';
-import Tile from 'components/lv2/Tile';
+import Tile from 'components/lv1/Tile';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -30,6 +30,7 @@ export default function (props) {
     katagamiWidth,
     katagamiHeight,
     dividing,
+    isSelecteds,
     handleToggleTile
   } = props;
   const fixedWidth = 640;
@@ -43,14 +44,15 @@ export default function (props) {
     tileHeight
   });
 
-  const Tiles = () => {
+  const TilesOnKatagami = () => {
     const labels = [];
-    for (let i = 1; i <= dividing; i++) {
+    for (let i = 0; i < dividing; i++) {
       labels.push(
         <Tile
           key={i}
           number={i}
           square={tileSquare}
+          isSelected={isSelecteds[i]}
           handleToggleTile={handleToggleTile}
         />
       );
@@ -60,8 +62,12 @@ export default function (props) {
 
   return (
     <div className={classes.root}>
-      <Grid container spacing={0} className={classes.katagami}>
-        <Tiles />
+      <Grid
+        container
+        spacing={0}
+        className={classes.katagami}
+      >
+        <TilesOnKatagami />
       </Grid>
     </div>
   );

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -2,10 +2,6 @@ import React, { useState, useEffect } from 'react';
 import {
   GridList,
   GridListTile,
-  Card,
-  CardContent,
-  CardActions,
-  Button
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/styles';
 import KatagamiCard from 'components/lv2/KatagamiCard';

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   GridList,
   GridListTile,

--- a/front/src/components/lv3/LabelList.js
+++ b/front/src/components/lv3/LabelList.js
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from 'react';
+import { makeStyles } from '@material-ui/styles';
+import { labelNameJp } from 'lib/format';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    border: '1px solid'
+  }
+}));
+
+export default function (props) {
+  const {
+    labels
+  } = props;
+  const classes = useStyles();
+
+  return (
+    <ul>
+      {labels.map(label =>
+        <li>{labelNameJp(label.name)}</li>
+      )}
+    </ul>
+  );
+}

--- a/front/src/components/lv3/LabelList.js
+++ b/front/src/components/lv3/LabelList.js
@@ -17,7 +17,7 @@ export default function (props) {
   return (
     <ul>
       {labels.map(label =>
-        <li>{labelNameJp(label.name)}</li>
+        <li key={label.id}>{labelNameJp(label.name)}</li>
       )}
     </ul>
   );

--- a/front/src/lib/api.js
+++ b/front/src/lib/api.js
@@ -65,6 +65,13 @@ export const createAnnotation = async (props) => {
   });
 }
 
+export const fetchLabels = async (handleGetLabels) => {
+  await fetchGet({
+    url: `${baseUrl}/labels`,
+    successAction: handleGetLabels
+  });
+}
+
 const fetchGet = async (props) => {
   const {
     url,

--- a/front/src/lib/api.js
+++ b/front/src/lib/api.js
@@ -82,7 +82,7 @@ const fetchGet = async (props) => {
   return await fetch(url)
     .then(response => response.json())
     .then(responseJson => {
-      console.log(responseJson);
+      // console.log(responseJson);
       if (successAction) {
         successAction(responseJson);
       }
@@ -111,11 +111,11 @@ const fetchPost = async(props) => {
   })
     .then(response => response.json())
     .then(responseJson => {
-      console.log(responseJson);
+      // console.log(responseJson);
       if (successAction) {
         successAction(responseJson);
       }
-      // console.log('fetch is finished');
+      // // console.log('fetch is finished');
     })
     .catch(error => {
       console.error(error);

--- a/front/src/lib/auth.js
+++ b/front/src/lib/auth.js
@@ -32,7 +32,7 @@ export const logout = () => {
 const isExpired = () => {
   const expirationHours = 6;
   const saved = localStorage.getItem('saved');
-  console.log(new Date().getTime() - saved);
+  // console.log(new Date().getTime() - saved);
   return (
     saved &&
     new Date().getTime() - saved > expirationHours * 60 * 60 * 1000

--- a/front/src/lib/format.js
+++ b/front/src/lib/format.js
@@ -1,0 +1,26 @@
+export const labelNameJp = nameEn => {
+  switch (nameEn) {
+    case 'kasuri':
+      return '絣'
+    case 'kiku':
+      return '菊'
+    case 'ume':
+      return '梅'
+    case 'hishi':
+      return '菱'
+    case 'sakura':
+      return '桜'
+    case 'karakusa':
+      return '唐草'
+    case 'chou':
+      return '蝶'
+    case 'matsu':
+      return '松'
+    case 'kamenokou':
+      return '亀甲'
+    case 'asanoha':
+      return '麻の葉'
+    default:
+      return '不明'
+  }
+}

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -25,9 +25,19 @@ export default function (props) {
   const [katagamiWidth, setKatagamiWidth] = useState(0);
   const [katagamiHeight, setKatagamiHeight] = useState(0);
   const [labels, setLabels] = useState([]);
+  const [selectedTiles, setSelectedTiles] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [islatest, setIsLatest] = useState(true);
   const classes = useStyles();
+
+  const handleToggleTile = number => {
+    if (selectedTiles.includes(number)) {
+      const _selectedTiles = selectedTiles.splice(selectedTiles.indexOf(number), 1);
+      setSelectedTiles(_selectedTiles);
+    } else {
+      setSelectedTiles([...selectedTiles, number]);
+    }
+  }
 
   useEffect(() => {
     const handleCreateAnnotation = response => {
@@ -71,6 +81,7 @@ export default function (props) {
             katagamiHeight={katagamiHeight}
             katagamiWidth={katagamiWidth}
             dividing={9}
+            handleToggleTile={handleToggleTile}
           />
         </Grid>
         <Grid item xs={5}>

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -33,10 +33,14 @@ export default function (props) {
   const classes = useStyles();
 
   const handleToggleTile = number => {
-    let newTiles = selectedTiles;
-    newTiles[number] = !newTiles[number];
-    setSelectedTiles(newTiles);
+    setSelectedTiles(
+      selectedTiles.map((tile, i) => i === number ? !tile : tile)
+    );
   }
+
+  useEffect(() => {
+    console.log(selectedTiles);
+  }, [selectedTiles]);
 
   useEffect(() => {
     const handleCreateAnnotation = response => {
@@ -70,7 +74,6 @@ export default function (props) {
     );
   }
 
-  console.log(selectedTiles);
   return (
     <Container>
       <HeadLine>アノテーション (Image {katagamiId})</HeadLine>
@@ -81,6 +84,7 @@ export default function (props) {
             katagamiHeight={katagamiHeight}
             katagamiWidth={katagamiWidth}
             dividing={tileNumber}
+            isSelecteds={selectedTiles}
             handleToggleTile={handleToggleTile}
           />
         </Grid>

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -5,11 +5,9 @@ import { createAnnotation, fetchLabels } from 'lib/api';
 import HeadLine from 'components/lv1/HeadLine';
 import { Grid } from '@material-ui/core';
 import LabelList from 'components/lv3/LabelList';
+import KatagamiImage from 'components/lv3/KatagamiImage';
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    border: '1px solid'
-  },
   katagami: {
     width: '640px',
     height: 'auto'
@@ -24,15 +22,19 @@ export default function (props) {
 
   const [annotation, setAnnotation] = useState(null);
   const [katagamiUrl, setKatagamiUrl] = useState('');
+  const [katagamiWidth, setKatagamiWidth] = useState(0);
+  const [katagamiHeight, setKatagamiHeight] = useState(0);
   const [labels, setLabels] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [islatest, setIsLatest] = useState(true);
   const classes = useStyles();
 
   useEffect(() => {
-    const handleCreateAnnotation = ({id, katagami_url}) => {
-      setAnnotation(id);
-      setKatagamiUrl(katagami_url);
+    const handleCreateAnnotation = response => {
+      setAnnotation(response.id);
+      setKatagamiUrl(response.katagami_url);
+      setKatagamiWidth(response.katagami_width);
+      setKatagamiHeight(response.katagami_height);
       setIsLoading(false);
     }
     setIsLoading(true);
@@ -64,10 +66,11 @@ export default function (props) {
       <HeadLine>アノテーション (Image {katagamiId})</HeadLine>
       <Grid container>
         <Grid item xs={7}>
-          <img
-            src={katagamiUrl}
-            alt={`Image ${katagamiId}`}
-            className={classes.katagami}
+          <KatagamiImage
+            katagamiUrl={katagamiUrl}
+            katagamiHeight={katagamiHeight}
+            katagamiWidth={katagamiWidth}
+            dividing={9}
           />
         </Grid>
         <Grid item xs={5}>

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -52,21 +52,25 @@ export default function (props) {
   }, [islatest]);
 
   if (isLoading) {
-    return <p>Loading...</p>;
+    return (
+      <Container>
+        <p>Loading...</p>
+      </Container>
+    );
   }
 
   return (
     <Container>
       <HeadLine>アノテーション (Image {katagamiId})</HeadLine>
       <Grid container>
-        <Grid item xs={6}>
-        <img
-        src={katagamiUrl}
-        alt={`Image ${katagamiId}`}
-        className={classes.katagami}
-      />
+        <Grid item xs={7}>
+          <img
+            src={katagamiUrl}
+            alt={`Image ${katagamiId}`}
+            className={classes.katagami}
+          />
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={5}>
           <LabelList labels={labels} />
         </Grid>
       </Grid>

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/styles';
 import Container from 'components/lv1/Container';
-import { createAnnotation } from 'lib/api';
+import { createAnnotation, fetchLabels } from 'lib/api';
 import HeadLine from 'components/lv1/HeadLine';
+import { Grid } from '@material-ui/core';
+import LabelList from 'components/lv3/LabelList';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -22,8 +24,9 @@ export default function (props) {
 
   const [annotation, setAnnotation] = useState(null);
   const [katagamiUrl, setKatagamiUrl] = useState('');
+  const [labels, setLabels] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [isCreated, setIsCreated] = useState(true);
+  const [islatest, setIsLatest] = useState(true);
   const classes = useStyles();
 
   useEffect(() => {
@@ -38,7 +41,15 @@ export default function (props) {
       katagamiId,
       handleCreateAnnotation
     });
-  }, [isCreated]);
+  }, [islatest]);
+
+  useEffect(() => {
+    const handleGetLabels = response => {
+      setLabels(response);
+    }
+    setIsLoading(true);
+    fetchLabels(handleGetLabels);
+  }, [islatest]);
 
   if (isLoading) {
     return <p>Loading...</p>;
@@ -47,11 +58,18 @@ export default function (props) {
   return (
     <Container>
       <HeadLine>アノテーション (Image {katagamiId})</HeadLine>
-      <img
+      <Grid container>
+        <Grid item xs={6}>
+        <img
         src={katagamiUrl}
         alt={`Image ${katagamiId}`}
         className={classes.katagami}
       />
+        </Grid>
+        <Grid item xs={6}>
+          <LabelList labels={labels} />
+        </Grid>
+      </Grid>
     </Container>
   );
 }

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -20,23 +20,22 @@ export default function (props) {
     katagamiId
   } = props.match.params;
 
+  const tileNumber = 9;
+
   const [annotation, setAnnotation] = useState(null);
   const [katagamiUrl, setKatagamiUrl] = useState('');
   const [katagamiWidth, setKatagamiWidth] = useState(0);
   const [katagamiHeight, setKatagamiHeight] = useState(0);
   const [labels, setLabels] = useState([]);
-  const [selectedTiles, setSelectedTiles] = useState([]);
+  const [selectedTiles, setSelectedTiles] = useState(new Array(tileNumber).fill(false));
   const [isLoading, setIsLoading] = useState(false);
   const [islatest, setIsLatest] = useState(true);
   const classes = useStyles();
 
   const handleToggleTile = number => {
-    if (selectedTiles.includes(number)) {
-      const _selectedTiles = selectedTiles.splice(selectedTiles.indexOf(number), 1);
-      setSelectedTiles(_selectedTiles);
-    } else {
-      setSelectedTiles([...selectedTiles, number]);
-    }
+    let newTiles = selectedTiles;
+    newTiles[number] = !newTiles[number];
+    setSelectedTiles(newTiles);
   }
 
   useEffect(() => {
@@ -71,6 +70,7 @@ export default function (props) {
     );
   }
 
+  console.log(selectedTiles);
   return (
     <Container>
       <HeadLine>アノテーション (Image {katagamiId})</HeadLine>
@@ -80,7 +80,7 @@ export default function (props) {
             katagamiUrl={katagamiUrl}
             katagamiHeight={katagamiHeight}
             katagamiWidth={katagamiWidth}
-            dividing={9}
+            dividing={tileNumber}
             handleToggleTile={handleToggleTile}
           />
         </Grid>

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -1,18 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles } from '@material-ui/styles';
 import Container from 'components/lv1/Container';
 import { createAnnotation, fetchLabels } from 'lib/api';
 import HeadLine from 'components/lv1/HeadLine';
 import { Grid } from '@material-ui/core';
 import LabelList from 'components/lv3/LabelList';
 import KatagamiImage from 'components/lv3/KatagamiImage';
-
-const useStyles = makeStyles(theme => ({
-  katagami: {
-    width: '640px',
-    height: 'auto'
-  }
-}));
 
 export default function (props) {
   const {
@@ -30,7 +22,6 @@ export default function (props) {
   const [selectedTiles, setSelectedTiles] = useState(new Array(tileNumber).fill(false));
   const [isLoading, setIsLoading] = useState(false);
   const [islatest, setIsLatest] = useState(true);
-  const classes = useStyles();
 
   const handleToggleTile = number => {
     setSelectedTiles(

--- a/front/src/serviceWorker.js
+++ b/front/src/serviceWorker.js
@@ -82,7 +82,7 @@ function registerValidSW(swUrl, config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              // console.log('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {

--- a/test/fixtures/labels.yml
+++ b/test/fixtures/labels.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/label_test.rb
+++ b/test/models/label_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LabelTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### アノテーション実行画面の作成 (1)
**やったこと 🙋‍♂️**
- [API] 型紙, ラベル, アノテーションのモデル作成.
- [API] AWS-S3から型紙画像データ(承認済みURL)の取得.
- [API] ラベルのseedデータ作成
- [front] 一覧 => アノテーションへの画面遷移
- [front] 各種コンポーネント作成


**できること 🙆‍♂️**
- ログイン後のTopにおいて, 型紙一覧から選択した型紙のアノテーション画面に遷移できる.
- アノテーション画面には以下が表示される.
  - 対象の型紙に(現状)9つのタイル
  - 作成済みのラベル一覧
- タイルをクリックすると, 選択(透過ライムイエロー)/非選択(そのまま)の状態を変化させることができる.

**やってないこと 🙅‍♂️**
- [API, front] アノテーション結果のDBへの保存.
