### PR TITLE
materialUI/themeの導入と型紙一覧のページネーション実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ gem 'rails-i18n'
 gem 'carrierwave'
 # awsにアプリケーションからアクセスするため
 gem 'aws-sdk'
+# 型紙一覧にページネーションを適用するため
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -907,6 +907,18 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.13, < 3)
     jmespath (1.4.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -1000,6 +1012,7 @@ DEPENDENCIES
   byebug
   carrierwave
   dotenv-rails (= 2.7.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick (~> 4.8)
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -7,8 +7,9 @@ class KatagamisController < ApplicationController
               .pluck(:id)
 
     # 型紙一覧の情報 アノテーション件数を表示するためinclude
-    # TODO : ページネーションへの対応
-    katagamis = Katagami.includes(:annotations).order(created_at: 'DESC')
+    katagamis = Katagami.includes(:annotations)
+                        .order(created_at: 'DESC')
+                        .page(params[:page]).per(5)
 
     # ある型紙 x をログイン中のユーザはアノテーション済みか ?
     # => A のなかに x が入っているか ?

--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -1,5 +1,25 @@
 class KatagamisController < ApplicationController
   def index
-    render json: Katagami.all.select(:id, :name)
+    # A.ログイン中のユーザがアノテーション済みの型紙のidsを取得
+    katagami_ids_current_user_done_annotation = 
+      Katagami.includes(annotations: [:user])
+              .where(annotations: {status: 2, user_id: params[:user_id]})
+              .pluck(:id)
+
+    # 型紙一覧の情報 アノテーション件数を表示するためinclude
+    # TODO : ページネーションへの対応
+    katagamis = Katagami.includes(:annotations).order(created_at: 'DESC')
+
+    # ある型紙 x をログイン中のユーザはアノテーション済みか ?
+    # => A のなかに x が入っているか ?
+    render json: katagamis.map {|katagami|
+      {
+        id: katagami.id,
+        name: katagami.name,
+        annotation_num: katagami.annotations.size,
+        done_by_current_user: 
+          !!katagami_ids_current_user_done_annotation.index(katagami.id)
+      }
+    }
   end
 end

--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -8,18 +8,20 @@ class KatagamisController < ApplicationController
 
     # 型紙一覧の情報 アノテーション件数を表示するためinclude
     katagamis = Katagami.includes(:annotations)
-                        .order(created_at: 'DESC')
-                        .page(params[:page]).per(5)
+                        .page(params[:page]).per(params[:per])
 
     # ある型紙 x をログイン中のユーザはアノテーション済みか ?
     # => A のなかに x が入っているか ?
-    render json: katagamis.map {|katagami|
-      {
-        id: katagami.id,
-        name: katagami.name,
-        annotation_num: katagami.annotations.size,
-        done_by_current_user: 
-          !!katagami_ids_current_user_done_annotation.index(katagami.id)
+    render json: {
+      count: Katagami._count,
+      katagamis: katagamis.map {|katagami|
+        {
+          id: katagami.id,
+          name: katagami.name,
+          annotation_num: katagami.annotations.size,
+          done_by_current_user: 
+            !!katagami_ids_current_user_done_annotation.index(katagami.id)
+        }
       }
     }
   end

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -11,6 +11,8 @@ class Katagami < ApplicationRecord
 
   mount_uploader :cw_obj, KatagamiUploader
 
+  @@_count = 0
+
   def self.s3_bucket
     Aws::S3::Resource.new(
       region: 'ap-northeast-1',
@@ -22,5 +24,15 @@ class Katagami < ApplicationRecord
   def presigned_url
     target = Katagami.s3_bucket.objects.select { |object| object.key === name }
     target[0].presigned_url(:get)
+  end
+
+  def self._count
+    @@_count = self.count if @@_count == 0
+    @@_count
+  end
+
+  def self.add_count n
+    @@_count += n
+    p @@_count
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   post '/login' , to: 'users#login'
   get 'users/:id', to: 'users#show'
   # Katagami
-  get '/katagamis', to: 'katagamis#index'
+  post '/katagamis', to: 'katagamis#index'
   # Annotation
   post '/annotations/:katagami_id/:user_id', to: 'annotations#create'
   post '/annotations/add_has_labels', to: 'annotations#add_has_labels'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,7 @@ Katagami.transaction do
       cw_obj: open(item_url)
     )
     katagami.save!
+    Katagami.add_count 1
   end
 end
 

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -7,7 +7,7 @@ import {
   useLocation,
   useHistory,
 } from 'react-router-dom'
-import { makeStyles } from '@material-ui/styles'
+import { makeStyles, ThemeProvider } from '@material-ui/styles'
 import { Box } from '@material-ui/core'
 import TopPage from 'pages/TopPage'
 import SignupPage from 'pages/SignupPage'
@@ -15,6 +15,7 @@ import LoginPage from 'pages/LoginPage'
 import AnnotationPage from 'pages/AnnotationPage'
 import Header from 'components/lv3/Header'
 import { isAuthenticated, logout } from 'libs/auth'
+import theme from 'libs/theme'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -65,19 +66,25 @@ export default function() {
   }
 
   return (
-    <BrowserRouter>
-      <Header isLoggedIn={isLoggedIn} handleLogout={handleLogout} />
-      <Box className={classes.root}>
-        <Switch>
-          <AuthRoute path="/signup" component={SignupPage} />
-          <AuthRoute path="/login" component={LoginPage} />
-          <PrivateRoute
-            path="/ant/:katagamiId/:userId"
-            component={AnnotationPage}
-          />
-          <PrivateRoute path="/" component={TopPage} />
-        </Switch>
-      </Box>
-    </BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <BrowserRouter>
+        <Header
+          isLoggedIn={isLoggedIn}
+          handleLogout={handleLogout}
+          theme={theme}
+        />
+        <Box className={classes.root}>
+          <Switch>
+            <AuthRoute path="/signup" component={SignupPage} />
+            <AuthRoute path="/login" component={LoginPage} />
+            <PrivateRoute
+              path="/ant/:katagamiId/:userId"
+              component={AnnotationPage}
+            />
+            <PrivateRoute path="/" component={TopPage} />
+          </Switch>
+        </Box>
+      </BrowserRouter>
+    </ThemeProvider>
   )
 }

--- a/front/src/components/lv1/Container.js
+++ b/front/src/components/lv1/Container.js
@@ -7,7 +7,7 @@ const useStyles = makeStyles(theme => ({
   container: {
     backgroundColor: grey[50],
     color: grey[800],
-    padding: '24px 40px 64px 40px',
+    padding: '40px 40px 64px 40px',
   },
 }))
 

--- a/front/src/components/lv1/HeadLine.js
+++ b/front/src/components/lv1/HeadLine.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/styles'
 import { indigo } from '@material-ui/core/colors'
+import { Typography } from '@material-ui/core'
 
 const useStyles = makeStyles(theme => ({
   root: {
     marginBottom: 40,
-    color: indigo[600],
+    // color: indigo[600],
   },
 }))
 
@@ -14,7 +15,7 @@ export default function(props) {
 
   return (
     <div className={classes.root}>
-      <h1>{props.children}</h1>
+      <Typography variant="h1">{props.children}</Typography>
       <hr />
     </div>
   )

--- a/front/src/components/lv1/HeadLine.js
+++ b/front/src/components/lv1/HeadLine.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/styles'
-import { indigo } from '@material-ui/core/colors'
 import { Typography } from '@material-ui/core'
 
 const useStyles = makeStyles(theme => ({

--- a/front/src/components/lv1/Tile.js
+++ b/front/src/components/lv1/Tile.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
     fontSize: 40,
   },
   selected: {
-    backgroundColor: 'rgba(205, 220, 57, 0.8)',
+    backgroundColor: 'rgba(133, 97, 197, 0.7)',
   },
 }))
 

--- a/front/src/components/lv1/UserIcon.js
+++ b/front/src/components/lv1/UserIcon.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Avatar } from '@material-ui/core'
+import { Avatar, Typography } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import { randomColor } from 'libs/color'
 
@@ -21,5 +21,9 @@ export default function({ email, id, size }) {
     size: size,
   })
 
-  return <Avatar className={classes.icon}>{email[0].toUpperCase()}</Avatar>
+  return (
+    <Avatar className={classes.icon}>
+      <Typography variant="body2">{email[0].toUpperCase()}</Typography>
+    </Avatar>
+  )
 }

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -6,6 +6,7 @@ const useStyles = makeStyles(theme => ({
   tableRow: {
     '& *': { fontWeight: 'normal' },
   },
+  name: { width: 600 },
   done: { color: theme.palette.primary.main },
   yet: { color: theme.palette.secondary.main },
 }))
@@ -18,7 +19,7 @@ export default props => {
       {katagamis.map(katagami => (
         <TableRow key={katagami.id} className={classes.tableRow}>
           <TableCell align="right">{katagami.id}</TableCell>
-          <TableCell>{katagami.name}</TableCell>
+          <TableCell className={classes.name}>{katagami.name}</TableCell>
           <TableCell align="right">{katagami.annotation_num}</TableCell>
           {katagami.done_by_current_user ? (
             <TableCell align="center" className={classes.done}>

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { TableRow, TableCell, TableBody } from '@material-ui/core'
+import { makeStyles } from '@material-ui/styles'
+
+const useStyles = makeStyles(theme => ({
+  tableRow: {
+    '& *': { fontWeight: 'normal' },
+  },
+  done: { color: theme.palette.primary.main },
+  yet: { color: theme.palette.secondary.main },
+}))
+
+export default props => {
+  const { katagamis, emptyRows } = props
+  const classes = useStyles()
+  return (
+    <TableBody>
+      {katagamis.map(katagami => (
+        <TableRow key={katagami.id} className={classes.tableRow}>
+          <TableCell align="right">{katagami.id}</TableCell>
+          <TableCell>{katagami.name}</TableCell>
+          <TableCell align="right">{katagami.annotation_num}</TableCell>
+          {katagami.done_by_current_user ? (
+            <TableCell align="center" className={classes.done}>
+              完了
+            </TableCell>
+          ) : (
+            <TableCell align="center" className={classes.yet}>
+              未達成
+            </TableCell>
+          )}
+        </TableRow>
+      ))}
+      {emptyRows > 0 && (
+        <TableRow style={{ height: 55 * emptyRows }}>
+          <TableCell colSpan={6} />
+        </TableRow>
+      )}
+    </TableBody>
+  )
+}

--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -111,7 +111,7 @@ export default props => {
   }
 
   const RubyLabelName = () => (
-    <Typography variant="body1">
+    <Typography>
       <ruby>
         {name.kanji}
         <rt>{name.ruby}</rt>

--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -6,6 +6,7 @@ import {
   ListItemText,
   Button,
   Grid,
+  Typography,
 } from '@material-ui/core'
 import {
   RadioButtonUnchecked,
@@ -14,19 +15,14 @@ import {
   Cancel,
   Check,
 } from '@material-ui/icons'
-import { indigo } from '@material-ui/core/colors'
 import { convertBoolToNumOfTiles, convertNumToBoolOfTiles } from 'libs/format'
 import { saveSelectedTiles, diplayedTiles } from 'libs/tile'
 
 const useStyles = makeStyles(theme => ({
   name: {
     marginLeft: props => (props.ruby.length === 3 ? -4 : 0),
-    fontSize: 20,
   },
-  tile: {
-    color: indigo[600],
-    fontSize: 20,
-  },
+  tile: {},
 }))
 
 export default props => {
@@ -104,10 +100,18 @@ export default props => {
   }
 
   const RubyLabelName = () => (
-    <ruby>
-      {name.kanji}
-      <rt>{name.ruby}</rt>
-    </ruby>
+    <Typography variant="body1">
+      <ruby>
+        {name.kanji}
+        <rt>{name.ruby}</rt>
+      </ruby>
+    </Typography>
+  )
+
+  const DisplayedTiles = () => (
+    <Typography variant="body1" color="primary">
+      {isEditingThis ? convertedSelectedTiles : diplayedTiles(i)}
+    </Typography>
   )
 
   return (
@@ -120,12 +124,12 @@ export default props => {
         )}
       </ListItemIcon>
       <ListItemText>
-        <Grid container className={classes.textWrapper}>
+        <Grid container>
           <Grid item xs={4} className={classes.name}>
             <RubyLabelName />
           </Grid>
           <Grid item xs={4} className={classes.tile}>
-            {isEditingThis ? convertedSelectedTiles : diplayedTiles(i)}
+            <DisplayedTiles />
           </Grid>
         </Grid>
       </ListItemText>

--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -20,9 +20,18 @@ import { saveSelectedTiles, diplayedTiles } from 'libs/tile'
 
 const useStyles = makeStyles(theme => ({
   name: {
-    marginLeft: props => (props.ruby.length === 3 ? -4 : 0),
+    // marginLeft: props => (props.ruby.length === 3 ? -4 : 0),
   },
-  tile: {},
+  tiles: {
+    paddingTop: 6,
+  },
+  buttons: {
+    width: 128,
+  },
+  single: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
 }))
 
 export default props => {
@@ -82,7 +91,7 @@ export default props => {
   const ActivatedButtons = () => {
     if (isEditingThis) {
       return (
-        <div>
+        <div classes={classes.buttons}>
           <Button color="primary" onClick={handleSave}>
             <Check />
           </Button>
@@ -93,9 +102,11 @@ export default props => {
       )
     }
     return (
-      <Button color="default" onClick={handleEdit} disabled={!isFocused}>
-        <Edit />
-      </Button>
+      <div className={classes.buttons + ' ' + classes.single}>
+        <Button color="default" onClick={handleEdit} disabled={!isFocused}>
+          <Edit />
+        </Button>
+      </div>
     )
   }
 
@@ -109,7 +120,7 @@ export default props => {
   )
 
   const DisplayedTiles = () => (
-    <Typography variant="body1" color="primary">
+    <Typography variant="body1" color="primary" className={classes.tiles}>
       {isEditingThis ? convertedSelectedTiles : diplayedTiles(i)}
     </Typography>
   )

--- a/front/src/components/lv2/PaginationActions.js
+++ b/front/src/components/lv2/PaginationActions.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { IconButton } from '@material-ui/core'
+import { makeStyles } from '@material-ui/styles'
+import {
+  FirstPage,
+  KeyboardArrowRight,
+  KeyboardArrowLeft,
+  LastPage,
+} from '@material-ui/icons'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+}))
+
+export default props => {
+  const { count, page, rowsPerPage, onChangePage } = props
+  const classes = useStyles()
+
+  const handleFirstPageButtonClick = event => {
+    onChangePage(event, 0)
+  }
+
+  const handleBackButtonClick = event => {
+    onChangePage(event, page - 1)
+  }
+
+  const handleNextButtonClick = event => {
+    onChangePage(event, page + 1)
+  }
+
+  const handleLastPageButtonClick = event => {
+    onChangePage(event, Math.ceil(count / rowsPerPage) - 1)
+  }
+
+  return (
+    <div className={classes.root}>
+      <IconButton onClick={handleFirstPageButtonClick} disabled={page === 0}>
+        <FirstPage />
+      </IconButton>
+      <IconButton onClick={handleBackButtonClick} disabled={page === 0}>
+        <KeyboardArrowLeft />
+      </IconButton>
+      <IconButton
+        onClick={handleNextButtonClick}
+        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+      >
+        <KeyboardArrowRight />
+      </IconButton>
+      <IconButton
+        onClick={handleLastPageButtonClick}
+        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+      >
+        <LastPage />
+      </IconButton>
+    </div>
+  )
+}

--- a/front/src/components/lv2/UserMenu.js
+++ b/front/src/components/lv2/UserMenu.js
@@ -107,9 +107,7 @@ export default function({ handleLogout }) {
               <ListItemIcon>
                 <AccountBox color="primary" />
               </ListItemIcon>
-              <ListItemText>
-                <Typography color="primary">マイページ</Typography>
-              </ListItemText>
+              <ListItemText primary="マイページ" />
             </ListItem>
           </Link>
         </MenuItem>
@@ -118,9 +116,7 @@ export default function({ handleLogout }) {
             <ListItemIcon>
               <ExitToApp color="primary" />
             </ListItemIcon>
-            <ListItemText>
-              <Typography color="primary">ログアウト</Typography>
-            </ListItemText>
+            <ListItemText primary="ログアウト" />
           </ListItem>
         </MenuItem>
       </Menu>

--- a/front/src/components/lv2/UserMenu.js
+++ b/front/src/components/lv2/UserMenu.js
@@ -8,27 +8,32 @@ import {
   Modal,
   Grid,
   Button,
-  Box,
+  Typography,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
 } from '@material-ui/core'
 import { AccountBox, ExitToApp } from '@material-ui/icons'
 import { grey } from '@material-ui/core/colors'
 import UserIcon from 'components/lv1/UserIcon'
 import { currentUser } from 'libs/auth'
+import theme from 'libs/theme'
 
 const useStyle = makeStyles(theme => ({
   link: {
     display: 'flex',
     flexDirection: 'row',
     textDecoration: 'none',
+    justifyContent: 'flex-start',
     alignItems: 'center',
-    color: grey[900],
   },
   menuItem: {
-    padding: '6px 32px',
+    width: 320,
   },
   icon: {
+    display: 'inlineBlock',
     marginTop: 5,
-    marginRight: 3,
+    marginRight: 8,
   },
   modal: {
     display: 'flex',
@@ -36,15 +41,16 @@ const useStyle = makeStyles(theme => ({
     justifyContent: 'center',
   },
   modalBody: {
-    width: 240,
+    width: 280,
     height: 120,
     padding: '16px 24px',
     backgroundColor: grey[50],
   },
   text: {
-    paddingBottom: 8,
+    padding: '24px 0',
   },
   button: {
+    width: 88,
     margin: '0 auto',
   },
 }))
@@ -54,7 +60,7 @@ export default function({ handleLogout }) {
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const open = Boolean(anchorEl)
   const user = currentUser()
-  const classes = useStyle()
+  const classes = useStyle(theme)
 
   const handleSafetyLogout = () => {
     setModalIsOpen(false)
@@ -97,17 +103,25 @@ export default function({ handleLogout }) {
           onClick={() => setAnchorEl(false)}
         >
           <Link to={`/users/${user.id}`} className={classes.link}>
-            <Box className={classes.icon}>
-              <AccountBox />
-            </Box>
-            マイページ
+            <ListItem>
+              <ListItemIcon>
+                <AccountBox color="primary" />
+              </ListItemIcon>
+              <ListItemText>
+                <Typography color="primary">マイページ</Typography>
+              </ListItemText>
+            </ListItem>
           </Link>
         </MenuItem>
         <MenuItem className={classes.menuItem} onClick={handleModalOpen}>
-          <Box className={classes.icon}>
-            <ExitToApp />
-          </Box>
-          ログアウト
+          <ListItem>
+            <ListItemIcon>
+              <ExitToApp color="primary" />
+            </ListItemIcon>
+            <ListItemText>
+              <Typography color="primary">ログアウト</Typography>
+            </ListItemText>
+          </ListItem>
         </MenuItem>
       </Menu>
       <Modal
@@ -118,7 +132,7 @@ export default function({ handleLogout }) {
         onClose={() => setModalIsOpen(false)}
       >
         <div className={classes.modalBody}>
-          <p className={classes.text}>ログアウトしますか？</p>
+          <Typography className={classes.text}>ログアウトしますか？</Typography>
           <Grid container>
             <Grid item xs={8}>
               <Button

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -11,6 +11,7 @@ const useStyles = makeStyles(theme => ({
   katagami: {
     backgroundImage: props => `url(${props.katagamiUrl})`,
     backgroundSize: 'cover',
+    border: props => (props.tileIsSelectable ? '2px solid #673ab7' : 'none'),
     width: props => `${props.fixedWidth}px`,
     height: props => `${props.fixedHeight}px`,
   },

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -49,7 +49,7 @@ export default function(props) {
           key={i}
           number={i}
           square={tileSquare}
-          isSelected={selectedTiles[i]}
+          isSelected={selectedTiles[i - 1]}
           handleToggleTile={handleToggleTile}
         />
       )

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -131,6 +131,12 @@ export default function() {
     setPage(newPage)
   }
 
+  const handleChangeRowsPerPage = event => {
+    handlePaginate({ page: 0, per: parseInt(event.target.value, 10) })
+    setRowsPerPage(parseInt(event.target.value, 10))
+    setPage(0)
+  }
+
   return (
     <div className={classes.root}>
       <Table>
@@ -168,7 +174,7 @@ export default function() {
               rowsPerPage={rowsPerPage}
               page={page}
               onChangePage={handleChangePage}
-              onChangeRowsPerPage={handlePaginate}
+              onChangeRowsPerPage={handleChangeRowsPerPage}
               ActionsComponent={PaginationActions}
             />
           </TableRow>

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   Table,
   TableHead,
@@ -10,6 +10,7 @@ import {
   TablePagination,
 } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
+import { currentUser } from 'libs/auth'
 import theme from 'libs/theme'
 import {
   FirstPage,
@@ -39,22 +40,42 @@ const useStyles = makeStyles(theme => ({
   yet: {
     color: theme.palette.secondary.main,
   },
+  footer: {
+    marginTop: theme.spacing(20),
+  },
+  footerButtons: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
 }))
 
 export default function(props) {
-  const { katagamis } = props
+  const { katagamis, handlePaginate } = props
+  const [page, setPage] = useState(1)
+  const [rowsPerPage, setRowsPerPage] = useState(5)
+  const user = currentUser()
   const classes = useStyles(theme)
 
   const PaginationActions = () => {
+    const { count, page, rowsPerPage, onChangePage } = props
+
+    const handleFirstPageButtonClick = () => {
+      onChangePage({ page: 1, per: rowsPerPage })
+    }
+
+    const handleLastPageButtonClick = () => {
+      onChangePage({ page: 0, per: rowsPerPage })
+    }
+
     return (
-      <div className={classes.footer}>
+      <div className={classes.footerButtons}>
         <IconButton>
           <FirstPage />
         </IconButton>
         <IconButton>
           <KeyboardArrowLeft />
         </IconButton>
-        <IconButton>
+        <IconButton onClick={() => console.log('hoge')}>
           <KeyboardArrowRight />
         </IconButton>
         <IconButton>
@@ -93,9 +114,17 @@ export default function(props) {
             </TableRow>
           ))}
         </TableBody>
-        <TableFooter>
+        <TableFooter className={classes.footer}>
           <TableRow className={classes.tableRow}>
-            <TablePagination ActionsComponent={PaginationActions} />
+            <TablePagination
+              rowsPerPageOptions={[5, 10, 25]}
+              count={10}
+              rowsPerPage={5}
+              page={0}
+              onChangePage={handlePaginate}
+              onChangeRowsPerPage={handlePaginate}
+              ActionsComponent={PaginationActions}
+            />
           </TableRow>
         </TableFooter>
       </Table>

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -57,7 +57,6 @@ export default function() {
   const [rowsPerPage, setRowsPerPage] = useState(5)
   const [isLoading, setIsLoading] = useState(false)
   const [isLatest, setIsLatest] = useState(true)
-  const user = currentUser()
   const classes = useStyles(theme)
 
   const handlePaginate = ({ page, per }) => {
@@ -100,21 +99,27 @@ export default function() {
     }
 
     const handleLastPageButtonClick = event => {
-      onChangePage(event, Math.ceil(count / rowsPerPage))
+      onChangePage(event, Math.ceil(count / rowsPerPage) - 1)
     }
 
     return (
       <div className={classes.footerButtons}>
-        <IconButton onClick={handleFirstPageButtonClick}>
+        <IconButton onClick={handleFirstPageButtonClick} disabled={page === 0}>
           <FirstPage />
         </IconButton>
-        <IconButton onClick={handleBackButtonClick}>
+        <IconButton onClick={handleBackButtonClick} disabled={page === 0}>
           <KeyboardArrowLeft />
         </IconButton>
-        <IconButton onClick={handleNextButtonClick}>
+        <IconButton
+          onClick={handleNextButtonClick}
+          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        >
           <KeyboardArrowRight />
         </IconButton>
-        <IconButton onClick={handleLastPageButtonClick}>
+        <IconButton
+          onClick={handleLastPageButtonClick}
+          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        >
           <LastPage />
         </IconButton>
       </div>

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -5,10 +5,18 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableFooter,
+  IconButton,
+  TablePagination,
 } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
-import { currentUser } from 'libs/auth'
 import theme from 'libs/theme'
+import {
+  FirstPage,
+  KeyboardArrowRight,
+  KeyboardArrowLeft,
+  LastPage,
+} from '@material-ui/icons'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -20,6 +28,11 @@ const useStyles = makeStyles(theme => ({
   tableHead: {
     backgroundColor: theme.palette.primary.light,
   },
+  tableRow: {
+    '& *': {
+      fontWeight: 'normal',
+    },
+  },
   done: {
     color: theme.palette.primary.main,
   },
@@ -30,8 +43,26 @@ const useStyles = makeStyles(theme => ({
 
 export default function(props) {
   const { katagamis } = props
-  const user = currentUser()
   const classes = useStyles(theme)
+
+  const PaginationActions = () => {
+    return (
+      <div className={classes.footer}>
+        <IconButton>
+          <FirstPage />
+        </IconButton>
+        <IconButton>
+          <KeyboardArrowLeft />
+        </IconButton>
+        <IconButton>
+          <KeyboardArrowRight />
+        </IconButton>
+        <IconButton>
+          <LastPage />
+        </IconButton>
+      </div>
+    )
+  }
 
   return (
     <div className={classes.root}>
@@ -46,7 +77,7 @@ export default function(props) {
         </TableHead>
         <TableBody>
           {katagamis.map(katagami => (
-            <TableRow key={katagami.id}>
+            <TableRow key={katagami.id} className={classes.tableRow}>
               <TableCell align="right">{katagami.id}</TableCell>
               <TableCell>{katagami.name}</TableCell>
               <TableCell align="right">{katagami.annotation_num}</TableCell>
@@ -62,6 +93,11 @@ export default function(props) {
             </TableRow>
           ))}
         </TableBody>
+        <TableFooter>
+          <TableRow className={classes.tableRow}>
+            <TablePagination ActionsComponent={PaginationActions} />
+          </TableRow>
+        </TableFooter>
       </Table>
     </div>
   )

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -4,21 +4,15 @@ import {
   TableHead,
   TableRow,
   TableCell,
-  TableBody,
   TableFooter,
-  IconButton,
   TablePagination,
 } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
 import { currentUser } from 'libs/auth'
 import { fetchKatagamis } from 'libs/api'
 import theme from 'libs/theme'
-import {
-  FirstPage,
-  KeyboardArrowRight,
-  KeyboardArrowLeft,
-  LastPage,
-} from '@material-ui/icons'
+import PaginationActions from 'components/lv2/PaginationActions'
+import KatagamiListBody from 'components/lv2/KatagamiListBody'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -27,27 +21,11 @@ const useStyles = makeStyles(theme => ({
     justifyContent: 'space-between',
     overflow: 'hidden',
   },
-  tableHead: {
-    backgroundColor: theme.palette.primary.light,
-  },
   tableRow: {
-    '& *': {
-      fontWeight: 'normal',
-    },
+    '& *': { fontWeight: 'normal' },
   },
-  done: {
-    color: theme.palette.primary.main,
-  },
-  yet: {
-    color: theme.palette.secondary.main,
-  },
-  footer: {
-    marginTop: theme.spacing(20),
-  },
-  footerButtons: {
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
+  header: { backgroundColor: theme.palette.primary.light },
+  footer: { marginTop: theme.spacing(20) },
 }))
 
 export default function() {
@@ -85,49 +63,6 @@ export default function() {
     })
   }, [isLatest])
 
-  const PaginationActions = props => {
-    const { count, page, rowsPerPage, onChangePage } = props
-
-    const handleFirstPageButtonClick = event => {
-      onChangePage(event, 0)
-    }
-
-    const handleBackButtonClick = event => {
-      onChangePage(event, page - 1)
-    }
-
-    const handleNextButtonClick = event => {
-      onChangePage(event, page + 1)
-    }
-
-    const handleLastPageButtonClick = event => {
-      onChangePage(event, Math.ceil(count / rowsPerPage) - 1)
-    }
-
-    return (
-      <div className={classes.footerButtons}>
-        <IconButton onClick={handleFirstPageButtonClick} disabled={page === 0}>
-          <FirstPage />
-        </IconButton>
-        <IconButton onClick={handleBackButtonClick} disabled={page === 0}>
-          <KeyboardArrowLeft />
-        </IconButton>
-        <IconButton
-          onClick={handleNextButtonClick}
-          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-        >
-          <KeyboardArrowRight />
-        </IconButton>
-        <IconButton
-          onClick={handleLastPageButtonClick}
-          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-        >
-          <LastPage />
-        </IconButton>
-      </div>
-    )
-  }
-
   const handleChangePage = (event, newPage) => {
     handlePaginate({ page: newPage, per: rowsPerPage })
     setPage(newPage)
@@ -143,36 +78,14 @@ export default function() {
     <div className={classes.root}>
       <Table>
         <TableHead>
-          <TableRow className={classes.tableHead}>
+          <TableRow className={classes.header}>
             <TableCell align="right">id</TableCell>
             <TableCell align="left">ファイル名</TableCell>
             <TableCell align="right">アノテーション件数</TableCell>
             <TableCell align="center">あなたの達成度</TableCell>
           </TableRow>
         </TableHead>
-        <TableBody>
-          {katagamis.map(katagami => (
-            <TableRow key={katagami.id} className={classes.tableRow}>
-              <TableCell align="right">{katagami.id}</TableCell>
-              <TableCell>{katagami.name}</TableCell>
-              <TableCell align="right">{katagami.annotation_num}</TableCell>
-              {katagami.done_by_current_user ? (
-                <TableCell align="center" className={classes.done}>
-                  完了
-                </TableCell>
-              ) : (
-                <TableCell align="center" className={classes.yet}>
-                  未達成
-                </TableCell>
-              )}
-            </TableRow>
-          ))}
-          {emptyRows > 0 && (
-            <TableRow style={{ height: 55 * emptyRows }}>
-              <TableCell colSpan={6} />
-            </TableRow>
-          )}
-        </TableBody>
+        <KatagamiListBody katagamis={katagamis} emptyRows={emptyRows} />
         <TableFooter className={classes.footer}>
           <TableRow className={classes.tableRow}>
             <TablePagination

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -1,8 +1,14 @@
 import React from 'react'
-import { GridList, GridListTile } from '@material-ui/core'
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
-import KatagamiCard from 'components/lv2/KatagamiCard'
 import { currentUser } from 'libs/auth'
+import theme from 'libs/theme'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -11,25 +17,52 @@ const useStyles = makeStyles(theme => ({
     justifyContent: 'space-between',
     overflow: 'hidden',
   },
-  gridList: {
-    width: '100%',
+  tableHead: {
+    backgroundColor: theme.palette.primary.light,
+  },
+  done: {
+    color: theme.palette.primary.main,
+  },
+  yet: {
+    color: theme.palette.secondary.main,
   },
 }))
 
 export default function(props) {
   const { katagamis } = props
   const user = currentUser()
-  const classes = useStyles()
+  const classes = useStyles(theme)
 
   return (
     <div className={classes.root}>
-      <GridList cellHeight={160} className={classes.gridList} cols={3}>
-        {katagamis.map(katagami => (
-          <GridListTile key={katagami.id}>
-            <KatagamiCard katagami={katagami} userId={user.id} />
-          </GridListTile>
-        ))}
-      </GridList>
+      <Table>
+        <TableHead>
+          <TableRow className={classes.tableHead}>
+            <TableCell align="right">id</TableCell>
+            <TableCell align="left">ファイル名</TableCell>
+            <TableCell align="right">アノテーション件数</TableCell>
+            <TableCell align="center">あなたの達成度</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {katagamis.map(katagami => (
+            <TableRow key={katagami.id}>
+              <TableCell align="right">{katagami.id}</TableCell>
+              <TableCell>{katagami.name}</TableCell>
+              <TableCell align="right">{katagami.annotation_num}</TableCell>
+              {katagami.done_by_current_user ? (
+                <TableCell align="center" className={classes.done}>
+                  完了
+                </TableCell>
+              ) : (
+                <TableCell align="center" className={classes.yet}>
+                  未達成
+                </TableCell>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   )
 }

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -57,6 +57,8 @@ export default function() {
   const [rowsPerPage, setRowsPerPage] = useState(5)
   const [isLoading, setIsLoading] = useState(false)
   const [isLatest, setIsLatest] = useState(true)
+  const emptyRows =
+    rowsPerPage - Math.min(rowsPerPage, count - page * rowsPerPage)
   const classes = useStyles(theme)
 
   const handlePaginate = ({ page, per }) => {
@@ -165,6 +167,11 @@ export default function() {
               )}
             </TableRow>
           ))}
+          {emptyRows > 0 && (
+            <TableRow style={{ height: 55 * emptyRows }}>
+              <TableCell colSpan={6} />
+            </TableRow>
+          )}
         </TableBody>
         <TableFooter className={classes.footer}>
           <TableRow className={classes.tableRow}>

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -33,8 +33,6 @@ export default function() {
   const [count, setCount] = useState(0)
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(5)
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLatest, setIsLatest] = useState(true)
   const emptyRows =
     rowsPerPage - Math.min(rowsPerPage, count - page * rowsPerPage)
   const classes = useStyles(theme)
@@ -44,9 +42,7 @@ export default function() {
       setKatagamis(response.katagamis)
       setCount(response.count)
       setPage(page)
-      setIsLoading(false)
     }
-    setIsLoading(true)
     fetchKatagamis({
       userId: currentUser().id,
       page: page + 1,
@@ -56,20 +52,14 @@ export default function() {
   }
 
   useEffect(() => {
-    setIsLoading(true)
-    handlePaginate({
-      page: page,
-      per: rowsPerPage,
-    })
-  }, [isLatest])
+    handlePaginate({ page: page, per: rowsPerPage })
+  }, [page, rowsPerPage])
 
   const handleChangePage = (event, newPage) => {
-    handlePaginate({ page: newPage, per: rowsPerPage })
     setPage(newPage)
   }
 
   const handleChangeRowsPerPage = event => {
-    handlePaginate({ page: 0, per: parseInt(event.target.value, 10) })
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
   }

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -42,7 +42,7 @@ export const fetchKatagamis = async props => {
   body.append('user_id', userId)
   body.append('page', page)
 
-  await fetchGet({
+  await fetchPost({
     url: `${baseUrl}/katagamis`,
     body: body,
     successAction: handleGetKatagamis,

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -37,10 +37,11 @@ export const fetchUser = async (id, handleGetUser) => {
 }
 
 export const fetchKatagamis = async props => {
-  const { userId, page, handleGetKatagamis } = props
+  const { userId, page, per, handleGetKatagamis } = props
   const body = new FormData()
   body.append('user_id', userId)
   body.append('page', page)
+  body.append('per', per)
 
   await fetchPost({
     url: `${baseUrl}/katagamis`,

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -36,9 +36,15 @@ export const fetchUser = async (id, handleGetUser) => {
   })
 }
 
-export const fetchKatagamis = async handleGetKatagamis => {
+export const fetchKatagamis = async props => {
+  const { userId, page, handleGetKatagamis } = props
+  const body = new FormData()
+  body.append('user_id', userId)
+  body.append('page', page)
+
   await fetchGet({
     url: `${baseUrl}/katagamis`,
+    body: body,
     successAction: handleGetKatagamis,
   })
 }

--- a/front/src/libs/format.js
+++ b/front/src/libs/format.js
@@ -29,7 +29,7 @@ export const labelNameJp = nameEn => {
 
 export const convertBoolToNumOfTiles = tileStates => {
   const numbersStr = tileStates
-    .map((tile, i) => (tile ? i : ' '))
+    .map((tile, i) => (tile ? i + 1 : ' '))
     .filter(number => number !== ' ')
     .join(' ')
 
@@ -41,7 +41,7 @@ export const convertNumToBoolOfTiles = saveTiles => {
   if (saveTiles) {
     saveTiles
       .split(' ')
-      .forEach(tileNumber => (convertArray[tileNumber] = true))
+      .forEach(tileNumber => (convertArray[tileNumber - 1] = true))
   }
   return convertArray
 }

--- a/front/src/libs/theme.js
+++ b/front/src/libs/theme.js
@@ -21,7 +21,7 @@ const typography = {
     color: '#030303',
   },
   body2: {
-    fontSize: 20,
+    fontSize: 16,
     fontWeight: 700,
     color: '#fafafa',
   },

--- a/front/src/libs/theme.js
+++ b/front/src/libs/theme.js
@@ -17,12 +17,16 @@ const typography = {
   },
   body1: {
     fontSize: 16,
+    color: '#030303',
   },
   body2: {
-    fontSize: 12,
+    fontSize: 20,
+    fontWeight: 700,
+    color: '#fafafa',
   },
   button: {
     fontSize: 16,
+    color: '#fafafa',
   },
 }
 

--- a/front/src/libs/theme.js
+++ b/front/src/libs/theme.js
@@ -1,0 +1,13 @@
+import { createMuiTheme } from '@material-ui/core/styles'
+
+const palette = {
+  primary: { main: '#00796B' },
+  secondary: { main: '#673AB7' },
+  error: { main: '#ef5350' },
+  warning: { main: '#cddc39' },
+  info: { main: '#004d40' },
+  success: { main: '#26c6da' },
+}
+const themeName = 'Hayato OKUMA Katagami annotation tool theme'
+
+export default createMuiTheme({ palette, themeName })

--- a/front/src/libs/theme.js
+++ b/front/src/libs/theme.js
@@ -1,4 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles'
+import { jaJP } from '@material-ui/core/locale'
 
 const palette = {
   primary: { main: '#00796B' },
@@ -32,4 +33,4 @@ const typography = {
 
 const themeName = 'Hayato OKUMA Katagami annotation tool theme'
 
-export default createMuiTheme({ palette, typography, themeName })
+export default createMuiTheme({ palette, typography, themeName }, jaJP)

--- a/front/src/libs/theme.js
+++ b/front/src/libs/theme.js
@@ -8,6 +8,24 @@ const palette = {
   info: { main: '#004d40' },
   success: { main: '#26c6da' },
 }
+
+const typography = {
+  h1: {
+    fontSize: 32,
+    fontWeight: 700,
+    color: palette.primary.main,
+  },
+  body1: {
+    fontSize: 16,
+  },
+  body2: {
+    fontSize: 12,
+  },
+  button: {
+    fontSize: 16,
+  },
+}
+
 const themeName = 'Hayato OKUMA Katagami annotation tool theme'
 
-export default createMuiTheme({ palette, themeName })
+export default createMuiTheme({ palette, typography, themeName })

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -14,9 +14,6 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     justifyContent: 'flex-end',
   },
-  button: {
-    fontSize: 20,
-  },
 }))
 
 export default function(props) {
@@ -119,7 +116,6 @@ export default function(props) {
         <Button
           variant="contained"
           color="secondary"
-          className={classes.button}
           onClick={() =>
             postHasLabels({
               annotationId: annotation,

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -118,7 +118,7 @@ export default function(props) {
       <Grid className={classes.submit}>
         <Button
           variant="contained"
-          color="secondary"
+          color="primary"
           className={classes.button}
           onClick={() =>
             postHasLabels({

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -14,6 +14,9 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     justifyContent: 'flex-end',
   },
+  button: {
+    width: 120,
+  },
 }))
 
 export default function(props) {
@@ -116,6 +119,7 @@ export default function(props) {
         <Button
           variant="contained"
           color="secondary"
+          className={classes.button}
           onClick={() =>
             postHasLabels({
               annotationId: annotation,

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -38,8 +38,9 @@ export default function(props) {
   const [isEditing, setIsEditing] = useState(false)
 
   const handleToggleTile = number => {
+    console.log(selectedTiles)
     setSelectedTiles(
-      selectedTiles.map((tile, i) => (i === number ? !tile : tile))
+      selectedTiles.map((tile, i) => (i === number - 1 ? !tile : tile))
     )
   }
 

--- a/front/src/pages/TopPage.js
+++ b/front/src/pages/TopPage.js
@@ -3,19 +3,30 @@ import Container from 'components/lv1/Container'
 import { fetchKatagamis } from 'libs/api'
 import KatagamiList from 'components/lv3/KatagamiList'
 import HeadLine from 'components/lv1/HeadLine'
+import { currentUser } from 'libs/auth'
 
 export default function() {
   const [katagamis, setKatagamis] = useState([])
   const [isLatest, setIsLateset] = useState(true)
   const [isLoading, setIsLoading] = useState(false)
 
-  useEffect(() => {
+  const handlePagenate = page => {
     const handleGetKatagamis = katagamis => {
+      console.log(katagamis)
       setKatagamis(katagamis)
       setIsLoading(false)
     }
     setIsLoading(true)
-    fetchKatagamis(handleGetKatagamis)
+    fetchKatagamis({
+      userId: currentUser().id,
+      page: page,
+      handleGetKatagamis: handleGetKatagamis,
+    })
+  }
+
+  useEffect(() => {
+    setIsLoading(true)
+    handlePagenate(1)
   }, [isLatest])
 
   if (isLoading) {

--- a/front/src/pages/TopPage.js
+++ b/front/src/pages/TopPage.js
@@ -1,48 +1,13 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import Container from 'components/lv1/Container'
-import { fetchKatagamis } from 'libs/api'
 import KatagamiList from 'components/lv3/KatagamiList'
 import HeadLine from 'components/lv1/HeadLine'
-import { currentUser } from 'libs/auth'
 
 export default function() {
-  const [katagamis, setKatagamis] = useState([])
-  const [count, setCount] = useState(0)
-  const [isLatest, setIsLateset] = useState(true)
-  const [isLoading, setIsLoading] = useState(false)
-
-  const handlePaginate = ({ page, per }) => {
-    const handleGetKatagamis = response => {
-      setKatagamis(response.katagamis)
-      setCount(response.count)
-      setIsLoading(false)
-    }
-    setIsLoading(true)
-    fetchKatagamis({
-      userId: currentUser().id,
-      page: page,
-      per: per,
-      handleGetKatagamis: handleGetKatagamis,
-    })
-  }
-
-  useEffect(() => {
-    setIsLoading(true)
-    handlePaginate({ page: 1, per: 5 })
-  }, [isLatest])
-
-  if (isLoading) {
-    return (
-      <Container>
-        <p>Loading...</p>
-      </Container>
-    )
-  }
-
   return (
     <Container>
       <HeadLine>画像一覧</HeadLine>
-      <KatagamiList katagamis={katagamis} handlePaginate={handlePaginate} />
+      <KatagamiList />
     </Container>
   )
 }

--- a/front/src/pages/TopPage.js
+++ b/front/src/pages/TopPage.js
@@ -7,26 +7,28 @@ import { currentUser } from 'libs/auth'
 
 export default function() {
   const [katagamis, setKatagamis] = useState([])
+  const [count, setCount] = useState(0)
   const [isLatest, setIsLateset] = useState(true)
   const [isLoading, setIsLoading] = useState(false)
 
-  const handlePagenate = page => {
-    const handleGetKatagamis = katagamis => {
-      console.log(katagamis)
-      setKatagamis(katagamis)
+  const handlePaginate = ({ page, per }) => {
+    const handleGetKatagamis = response => {
+      setKatagamis(response.katagamis)
+      setCount(response.count)
       setIsLoading(false)
     }
     setIsLoading(true)
     fetchKatagamis({
       userId: currentUser().id,
       page: page,
+      per: per,
       handleGetKatagamis: handleGetKatagamis,
     })
   }
 
   useEffect(() => {
     setIsLoading(true)
-    handlePagenate(1)
+    handlePaginate({ page: 1, per: 5 })
   }, [isLatest])
 
   if (isLoading) {
@@ -40,7 +42,7 @@ export default function() {
   return (
     <Container>
       <HeadLine>画像一覧</HeadLine>
-      <KatagamiList katagamis={katagamis} />
+      <KatagamiList katagamis={katagamis} handlePaginate={handlePaginate} />
     </Container>
   )
 }


### PR DESCRIPTION
## やったこと
### front
- materialUI/theme を自作して, カラーセット, タイポグラフィの設定を全体的に行った.
- themeを使いながらスタイルの調整も行った.
- TopPage に表示させている型紙一覧の表示形式を表に変更.
- ページネーションも合わせて実装. マテニキ様様である.
### API
- 型紙一覧の表示形式変更に合わせて, `katagamis/index` で取得するデータをリッチに.
- frontに対応すべく, gem `kaminari`をインポートして機能を実装
<br />

## できるようになったこと
- TopPageで型紙一覧が表形式で確認できる.
  - アノテーション件数と自身の達成度を新規追加
- ページネーションを使って, 画面遷移なしで別ページの型紙一覧に移れる.
  - Router経由した方がいいか..? まあいいや
- ページごとに表示するデータ件数も動的に変更できる.

![table-1232](https://user-images.githubusercontent.com/39250854/71613195-582d6b00-2be8-11ea-8988-a77ffc53b074.gif)
<br />

## やってないこと
### front
- TopPage => AnnotationPage への導線作成
- API から fetch 中の挙動 (Supenceとか)
  - Loadingによって見た目切り替わるのがきもいので一旦しなくてよしとする.
  - 実データ並みに多く使って気になるなら実装とか
### API
- `katagamis/index` のキャッシュ
  - AWS から取得する`presinged_url` とかもやった方が安心
