### PR TITLE
型紙一覧からアノテーション実行への導線を設置

### DIFF
--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -15,7 +15,6 @@ class KatagamisController < ApplicationController
         # 型紙一覧の情報 アノテーション件数を表示するためinclude
         katagamis = Katagami.includes(:annotations)
                             .page(params[:page]).per(params[:per])
-                            .order(created_at: 'DESC')
 
 
         # ある型紙 x をログイン中のユーザはアノテーション済みか ?

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -22,10 +22,8 @@ class Katagami < ApplicationRecord
   end
 
   def presigned_url
-    Rails.cache.fetch('katagami-' + self.id) do
-      target = Katagami.s3_bucket.objects.select { |object| object.key === name }
-      target[0].presigned_url(:get)
-    end
+    target = Katagami.s3_bucket.objects.select { |object| object.key === name }
+    target[0].presigned_url(:get)
   end
 
   def self._count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   post '/login' , to: 'users#login'
   get 'users/:id', to: 'users#show'
   # Katagami
-  post '/katagamis/:page/:per', to: 'katagamis#index'
+  get '/katagamis/:user/:page/:per', to: 'katagamis#index'
   # Annotation
   post '/annotations/:katagami_id/:user_id', to: 'annotations#create'
   post '/annotations/add_has_labels', to: 'annotations#add_has_labels'

--- a/front/src/components/lv1/HeadLine.js
+++ b/front/src/components/lv1/HeadLine.js
@@ -3,10 +3,7 @@ import { makeStyles } from '@material-ui/styles'
 import { Typography } from '@material-ui/core'
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    marginBottom: 40,
-    // color: indigo[600],
-  },
+  root: { marginBottom: 40 },
 }))
 
 export default function(props) {

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -1,18 +1,25 @@
 import React from 'react'
-import { TableRow, TableCell, TableBody } from '@material-ui/core'
+import {
+  TableRow,
+  TableCell,
+  TableBody,
+  Button,
+  IconButton,
+} from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
+import { NoteAdd, List, Create, Link } from '@material-ui/icons'
 
 const useStyles = makeStyles(theme => ({
   tableRow: {
     '& *': { fontWeight: 'normal' },
   },
-  name: { width: 600 },
   done: { color: theme.palette.primary.main },
   yet: { color: theme.palette.secondary.main },
+  button: { padding: 4 },
 }))
 
 export default props => {
-  const { katagamis, emptyRows } = props
+  const { katagamis, emptyRows, handleSelectId } = props
   const classes = useStyles()
   return (
     <TableBody>
@@ -23,13 +30,27 @@ export default props => {
           <TableCell align="right">{katagami.annotation_num}</TableCell>
           {katagami.done_by_current_user ? (
             <TableCell align="center" className={classes.done}>
-              完了
+              実行済
             </TableCell>
           ) : (
             <TableCell align="center" className={classes.yet}>
-              未達成
+              未実行
             </TableCell>
           )}
+          <TableCell align="center">
+            <IconButton className={classes.button}>
+              <Link />
+            </IconButton>
+          </TableCell>
+          <TableCell>
+            <IconButton
+              color="primary"
+              className={classes.button}
+              onClick={() => handleSelectId(katagami.id)}
+            >
+              <Create />
+            </IconButton>
+          </TableCell>
         </TableRow>
       ))}
       {emptyRows > 0 && (

--- a/front/src/components/lv2/Modal.js
+++ b/front/src/components/lv2/Modal.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/styles'
+import { Modal, Button, Typography } from '@material-ui/core'
+import { grey } from '@material-ui/core/colors'
+
+const useStyles = makeStyles(theme => ({
+  modal: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  modalBody: {
+    width: 640,
+    padding: '16px 24px 24px 24px',
+    backgroundColor: grey[50],
+  },
+  text: {
+    padding: '24px 0',
+  },
+  buttonWrapper: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: 24,
+  },
+  button: {
+    width: 88,
+    marginLeft: 24,
+  },
+}))
+
+export default props => {
+  const {
+    isOpen,
+    onClose,
+    title,
+    text,
+    yesText,
+    noText,
+    handleAnswerYes,
+    handleAnswerNo,
+  } = props
+  const classes = useStyles()
+
+  return (
+    <Modal
+      aria-labelledby="logunt-modal"
+      aria-describedby="logout-modal-description"
+      className={classes.modal}
+      open={isOpen}
+      onClose={onClose}
+    >
+      <div className={classes.modalBody}>
+        <Typography variant="h2" className={classes.text}>
+          {title}
+        </Typography>
+        <Typography>{text}</Typography>
+        <div className={classes.buttonWrapper}>
+          <Button
+            variant="contained"
+            color="primary"
+            className={classes.button}
+            onClick={handleAnswerYes}
+          >
+            {yesText}
+          </Button>
+          <Button
+            variant="contained"
+            className={classes.button}
+            onClick={handleAnswerNo}
+          >
+            {noText}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/front/src/components/lv2/UserMenu.js
+++ b/front/src/components/lv2/UserMenu.js
@@ -5,17 +5,13 @@ import {
   IconButton,
   Menu,
   MenuItem,
-  Modal,
-  Grid,
-  Button,
-  Typography,
   ListItem,
   ListItemIcon,
   ListItemText,
 } from '@material-ui/core'
 import { AccountBox, ExitToApp } from '@material-ui/icons'
-import { grey } from '@material-ui/core/colors'
 import UserIcon from 'components/lv1/UserIcon'
+import Modal from 'components/lv2/Modal'
 import { currentUser } from 'libs/auth'
 import theme from 'libs/theme'
 
@@ -35,28 +31,6 @@ const useStyle = makeStyles(theme => ({
     marginTop: 5,
     marginRight: 8,
   },
-  modal: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  modalBody: {
-    width: 640,
-    padding: '16px 24px 24px 24px',
-    backgroundColor: grey[50],
-  },
-  text: {
-    padding: '24px 0',
-  },
-  buttonWrapper: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    marginTop: 24,
-  },
-  button: {
-    width: 88,
-    marginLeft: 24,
-  },
 }))
 
 export default function({ handleLogout }) {
@@ -75,6 +49,10 @@ export default function({ handleLogout }) {
   const handleModalOpen = () => {
     setAnchorEl(false)
     setModalIsOpen(true)
+  }
+
+  const handleModalClose = () => {
+    setModalIsOpen(false)
   }
 
   return (
@@ -125,38 +103,15 @@ export default function({ handleLogout }) {
         </MenuItem>
       </Menu>
       <Modal
-        aria-labelledby="logunt-modal"
-        aria-describedby="logout-modal-description"
-        className={classes.modal}
-        open={modalIsOpen}
-        onClose={() => setModalIsOpen(false)}
-      >
-        <div className={classes.modalBody}>
-          <Typography variant="h2" className={classes.text}>
-            ログアウトしますか？
-          </Typography>
-          <Typography>
-            ログアウトした場合, 編集中の情報は保存されません.
-          </Typography>
-          <div className={classes.buttonWrapper}>
-            <Button
-              variant="contained"
-              color="primary"
-              className={classes.button}
-              onClick={handleSafetyLogout}
-            >
-              はい
-            </Button>
-            <Button
-              variant="contained"
-              className={classes.button}
-              onClick={() => setModalIsOpen(false)}
-            >
-              いいえ
-            </Button>
-          </div>
-        </div>
-      </Modal>
+        isOpen={modalIsOpen}
+        onClose={handleModalClose}
+        title="ログアウトしますか？"
+        text="ログアウトした場合, 編集中の情報は保存されません."
+        yesText="はい"
+        noText="いいえ"
+        handleAnswerYes={handleSafetyLogout}
+        handleAnswerNo={handleModalClose}
+      />
     </div>
   )
 }

--- a/front/src/components/lv2/UserMenu.js
+++ b/front/src/components/lv2/UserMenu.js
@@ -41,17 +41,21 @@ const useStyle = makeStyles(theme => ({
     justifyContent: 'center',
   },
   modalBody: {
-    width: 280,
-    height: 120,
-    padding: '16px 24px',
+    width: 640,
+    padding: '16px 24px 24px 24px',
     backgroundColor: grey[50],
   },
   text: {
     padding: '24px 0',
   },
+  buttonWrapper: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: 24,
+  },
   button: {
     width: 88,
-    margin: '0 auto',
+    marginLeft: 24,
   },
 }))
 
@@ -128,28 +132,29 @@ export default function({ handleLogout }) {
         onClose={() => setModalIsOpen(false)}
       >
         <div className={classes.modalBody}>
-          <Typography className={classes.text}>ログアウトしますか？</Typography>
-          <Grid container>
-            <Grid item xs={8}>
-              <Button
-                variant="contained"
-                color="primary"
-                className={classes.button}
-                onClick={handleSafetyLogout}
-              >
-                はい
-              </Button>
-            </Grid>
-            <Grid item xs={4}>
-              <Button
-                variant="contained"
-                className={classes.button}
-                onClick={() => setModalIsOpen(false)}
-              >
-                いいえ
-              </Button>
-            </Grid>
-          </Grid>
+          <Typography variant="h2" className={classes.text}>
+            ログアウトしますか？
+          </Typography>
+          <Typography>
+            ログアウトした場合, 編集中の情報は保存されません.
+          </Typography>
+          <div className={classes.buttonWrapper}>
+            <Button
+              variant="contained"
+              color="primary"
+              className={classes.button}
+              onClick={handleSafetyLogout}
+            >
+              はい
+            </Button>
+            <Button
+              variant="contained"
+              className={classes.button}
+              onClick={() => setModalIsOpen(false)}
+            >
+              いいえ
+            </Button>
+          </div>
         </div>
       </Modal>
     </div>

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -13,6 +13,7 @@ import { fetchKatagamis } from 'libs/api'
 import theme from 'libs/theme'
 import PaginationActions from 'components/lv2/PaginationActions'
 import KatagamiListBody from 'components/lv2/KatagamiListBody'
+import Modal from 'components/lv2/Modal'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -20,6 +21,10 @@ const useStyles = makeStyles(theme => ({
     flexWrap: 'wrap',
     justifyContent: 'space-between',
     overflow: 'hidden',
+  },
+  antButton: {
+    left: '85%',
+    marginBottom: 16,
   },
   tableRow: {
     '& *': { fontWeight: 'normal' },
@@ -33,8 +38,11 @@ export default function() {
   const [count, setCount] = useState(0)
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(5)
+  const [selectedId, setSelectedId] = useState(0)
+  const [modalIsOpen, setModalIsOpen] = useState(false)
   const emptyRows =
     rowsPerPage - Math.min(rowsPerPage, count - page * rowsPerPage)
+  const user = currentUser()
   const classes = useStyles(theme)
 
   const handlePaginate = ({ page, per }) => {
@@ -44,16 +52,12 @@ export default function() {
       setPage(page)
     }
     fetchKatagamis({
-      userId: currentUser().id,
+      userId: user.id,
       page: page + 1,
       per: per,
       handleGetKatagamis: handleGetKatagamis,
     })
   }
-
-  useEffect(() => {
-    handlePaginate({ page: page, per: rowsPerPage })
-  }, [page, rowsPerPage])
 
   const handleChangePage = (event, newPage) => {
     setPage(newPage)
@@ -64,6 +68,23 @@ export default function() {
     setPage(0)
   }
 
+  const handleDoAnnotation = () => {
+    window.location.href = `ant/${selectedId}/${user.id}`
+  }
+
+  const handleModalClose = () => {
+    setModalIsOpen(false)
+  }
+
+  const handleSelectId = id => {
+    setSelectedId(id)
+    setModalIsOpen(true)
+  }
+
+  useEffect(() => {
+    handlePaginate({ page: page, per: rowsPerPage })
+  }, [page, rowsPerPage])
+
   return (
     <div className={classes.root}>
       <Table>
@@ -72,10 +93,16 @@ export default function() {
             <TableCell align="right">id</TableCell>
             <TableCell align="left">ファイル名</TableCell>
             <TableCell align="right">アノテーション件数</TableCell>
-            <TableCell align="center">あなたの達成度</TableCell>
+            <TableCell align="center">ステータス</TableCell>
+            <TableCell align="center">結果一覧</TableCell>
+            <TableCell align="center"></TableCell>
           </TableRow>
         </TableHead>
-        <KatagamiListBody katagamis={katagamis} emptyRows={emptyRows} />
+        <KatagamiListBody
+          katagamis={katagamis}
+          emptyRows={emptyRows}
+          handleSelectId={handleSelectId}
+        />
         <TableFooter className={classes.footer}>
           <TableRow className={classes.tableRow}>
             <TablePagination
@@ -90,6 +117,16 @@ export default function() {
           </TableRow>
         </TableFooter>
       </Table>
+      <Modal
+        isOpen={modalIsOpen}
+        onClose={handleModalClose}
+        title="アノテーションを実行しますか？"
+        text="1回約5分で完了します."
+        yesText="はい"
+        noText="いいえ"
+        handleAnswerYes={handleDoAnnotation}
+        handleAnswerNo={handleModalClose}
+      />
     </div>
   )
 }

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -38,14 +38,9 @@ export const fetchUser = async (id, handleGetUser) => {
 
 export const fetchKatagamis = async props => {
   const { userId, page, per, handleGetKatagamis } = props
-  const body = new FormData()
-  body.append('user_id', userId)
-  body.append('page', page)
-  body.append('per', per)
 
-  await fetchPost({
-    url: `${baseUrl}/katagamis/${page}/${per}`,
-    body: body,
+  await fetchGet({
+    url: `${baseUrl}/katagamis/${userId}/${page}/${per}`,
     successAction: handleGetKatagamis,
   })
 }

--- a/front/src/libs/theme.js
+++ b/front/src/libs/theme.js
@@ -16,6 +16,11 @@ const typography = {
     fontWeight: 700,
     color: palette.primary.main,
   },
+  h2: {
+    fontSize: 24,
+    fontWeight: 700,
+    color: palette.primary.main,
+  },
   body1: {
     fontSize: 16,
     color: '#030303',


### PR DESCRIPTION
## やったこと
### front
- ログアウト時に出していたモーダルをオリジナルの `Modal` コンポーネントとしてリファクタ.
-  その`Modal` を使って, アノテーション実行への導線を設置
- 型紙一覧にカラムを追加
  - 結果一覧 : リンク
  - アノテーション実行 : モーダルを出す
### API
- アノテーションページに遷移したときにエラーに気付いて, キャッシュの取り方を修正

<br />

## できるようになったこと
- トップページからモーダルを経由してアノテーションページに飛べる.

![image](https://user-images.githubusercontent.com/39250854/71714177-20c0f780-2e50-11ea-8076-e5476fc0cf92.png)
<br />

## やってないこと
### front
- 結果一覧ページの作成
### API
- アノテーション件数, ステータス検知の正常動作
- 型紙一覧の条件付きGET
  - キャッシュの有効期限内に情報が更新されても, 期限超えないと反映されない.
