### PR TITLE
アノテーション完了時に確認モーダル設置 + トップに戻る実装

### DIFF
--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -4,7 +4,7 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Button,
+  IconButton,
   Grid,
   Typography,
 } from '@material-ui/core'
@@ -19,15 +19,8 @@ import { convertBoolToNumOfTiles, convertNumToBoolOfTiles } from 'libs/format'
 import { saveSelectedTiles, diplayedTiles } from 'libs/tile'
 
 const useStyles = makeStyles(theme => ({
-  name: {
-    // marginLeft: props => (props.ruby.length === 3 ? -4 : 0),
-  },
-  tiles: {
-    paddingTop: 6,
-  },
-  buttons: {
-    width: 128,
-  },
+  tiles: { paddingTop: 6 },
+  buttons: { width: 128 },
   single: {
     display: 'flex',
     justifyContent: 'flex-end',
@@ -86,26 +79,24 @@ export default props => {
     }
   }, [isEditingThis, i, setSelectedTiles])
 
-  console.log(typeof name.ruby.length)
-
   const ActivatedButtons = () => {
     if (isEditingThis) {
       return (
         <div classes={classes.buttons}>
-          <Button color="primary" onClick={handleSave}>
+          <IconButton color="primary" onClick={handleSave}>
             <Check />
-          </Button>
-          <Button color="secondary" onClick={handleCancelEdit}>
+          </IconButton>
+          <IconButton color="secondary" onClick={handleCancelEdit}>
             <Cancel />
-          </Button>
+          </IconButton>
         </div>
       )
     }
     return (
       <div className={classes.buttons + ' ' + classes.single}>
-        <Button color="default" onClick={handleEdit} disabled={!isFocused}>
+        <IconButton color="default" onClick={handleEdit} disabled={!isFocused}>
           <Edit />
-        </Button>
+        </IconButton>
       </div>
     )
   }

--- a/front/src/libs/format.js
+++ b/front/src/libs/format.js
@@ -1,5 +1,6 @@
 import { savedTiles } from './tile'
 
+// APIから取得したラベル名を日本語化
 export const labelNameJp = nameEn => {
   switch (nameEn) {
     case 'kasuri':
@@ -27,6 +28,7 @@ export const labelNameJp = nameEn => {
   }
 }
 
+// ラベル付け : state (Array of Boolean) => レンダリング用 (String)
 export const convertBoolToNumOfTiles = tileStates => {
   const numbersStr = tileStates
     .map((tile, i) => (tile ? i + 1 : ' '))
@@ -36,6 +38,7 @@ export const convertBoolToNumOfTiles = tileStates => {
   return numbersStr ? numbersStr : '該当無し'
 }
 
+// ラベル付け : レンダリング用 (String) => state (Array of Boolean)
 export const convertNumToBoolOfTiles = saveTiles => {
   let convertArray = new Array(9).fill(false)
   if (saveTiles) {
@@ -46,5 +49,10 @@ export const convertNumToBoolOfTiles = saveTiles => {
   return convertArray
 }
 
+// ラベル付け : 保存済み (Array of Number) => POST用 (String)
 export const hasLabelsForPost = labels =>
   labels.map((label, i) => label.id + ' ' + savedTiles(i)).join(',')
+
+// idを0詰め表示
+export const zeroPaddingOf = (num, zeros) =>
+  (new Array(zeros).fill(0).join('') + num).slice(-1 * zeros)

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from 'react'
 import Container from 'components/lv1/Container'
 import { createAnnotation, fetchLabels, postHasLabels } from 'libs/api'
-import HeadLine from 'components/lv1/HeadLine'
 import { Grid, Button } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
+import HeadLine from 'components/lv1/HeadLine'
+import Modal from 'components/lv2/Modal'
 import LabelList from 'components/lv3/LabelList'
 import KatagamiImage from 'components/lv3/KatagamiImage'
 import { initAllTiles } from 'libs/tile'
-import { hasLabelsForPost } from 'libs/format'
-import Modal from 'components/lv2/Modal'
+import { hasLabelsForPost, zeroPaddingOf } from 'libs/format'
 
 const useStyles = makeStyles(theme => ({
   submit: {
@@ -24,6 +24,7 @@ export default function(props) {
   const { userId, katagamiId } = props.match.params
 
   const tileNumber = 9
+  const zeroPaddingId = zeroPaddingOf(katagamiId, 6)
   const classes = useStyles()
 
   const [annotation, setAnnotation] = useState(null)
@@ -104,7 +105,7 @@ export default function(props) {
 
   return (
     <Container>
-      <HeadLine>型紙 id : {katagamiId}</HeadLine>
+      <HeadLine>型紙 id : {zeroPaddingId}</HeadLine>
       <Grid container>
         <Grid item xs={7}>
           <KatagamiImage

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -8,6 +8,7 @@ import LabelList from 'components/lv3/LabelList'
 import KatagamiImage from 'components/lv3/KatagamiImage'
 import { initAllTiles } from 'libs/tile'
 import { hasLabelsForPost } from 'libs/format'
+import Modal from 'components/lv2/Modal'
 
 const useStyles = makeStyles(theme => ({
   submit: {
@@ -36,6 +37,7 @@ export default function(props) {
   const [tileIsSelectable, setTileIsSelectable] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
+  const [modalIsOpen, setModalIsOpen] = useState(false)
 
   const handleToggleTile = number => {
     console.log(selectedTiles)
@@ -44,8 +46,23 @@ export default function(props) {
     )
   }
 
-  const handleCompleteAnnotation = response => {
-    console.log(response)
+  const handleSaveAnnotation = () => {
+    const handleCompleteAnnotation = response => {
+      window.location.href = '/'
+    }
+    postHasLabels({
+      annotationId: annotation,
+      hasLabels: hasLabelsForPost(labels),
+      handleCompleteAnnotation: handleCompleteAnnotation,
+    })
+  }
+
+  const handleModalOpen = () => {
+    setModalIsOpen(true)
+  }
+
+  const handleModalClose = () => {
+    setModalIsOpen(false)
   }
 
   // to fecth Katagami image
@@ -87,7 +104,7 @@ export default function(props) {
 
   return (
     <Container>
-      <HeadLine>アノテーション (Image {katagamiId})</HeadLine>
+      <HeadLine>型紙 id : {katagamiId}</HeadLine>
       <Grid container>
         <Grid item xs={7}>
           <KatagamiImage
@@ -121,17 +138,21 @@ export default function(props) {
           variant="contained"
           color="primary"
           className={classes.button}
-          onClick={() =>
-            postHasLabels({
-              annotationId: annotation,
-              hasLabels: hasLabelsForPost(labels),
-              handleCompleteAnnotation: handleCompleteAnnotation,
-            })
-          }
+          onClick={handleModalOpen}
         >
           完了
         </Button>
       </Grid>
+      <Modal
+        isOpen={modalIsOpen}
+        onClose={handleModalClose}
+        title="アノテーション結果を保存しますか？"
+        text="「該当無し」という結果もデータとして保存されます."
+        yesText="保存"
+        noText="戻る"
+        handleAnswerYes={handleSaveAnnotation}
+        handleAnswerNo={handleModalClose}
+      />
     </Container>
   )
 }


### PR DESCRIPTION
## やったこと
### front
- アノテーション完了時に確認モーダルを設置
  - 保存 => POSTしてトップに戻る 
  - 戻る => モーダル閉じる
- `Label`コンポーネントの微調整
- アノテーションページのヘッドラインを`id`に変更
  - せっかくなので`zero-padding`
<br />

## できるようになったこと
- アノテーションをいきなりPOSTせず, モーダルで確認できる.
  - 確認後, 保存でトップに戻れる.
  - 戻るでアノテーションを続けられる.

![image](https://user-images.githubusercontent.com/39250854/71774594-621ee780-2fb5-11ea-906c-9c4a753519dc.png)

<br />

## やってないこと
### front
- POST中のローダーが欲しい.
