### PR TITLE
アノテーション結果保存時のLoadingBar表示

### DIFF
--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -1,13 +1,7 @@
 import React from 'react'
-import {
-  TableRow,
-  TableCell,
-  TableBody,
-  Button,
-  IconButton,
-} from '@material-ui/core'
+import { TableRow, TableCell, TableBody, IconButton } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
-import { NoteAdd, List, Create, Link } from '@material-ui/icons'
+import { Create, Link } from '@material-ui/icons'
 
 const useStyles = makeStyles(theme => ({
   tableRow: {

--- a/front/src/components/lv2/LoadingModal.js
+++ b/front/src/components/lv2/LoadingModal.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/styles'
+import { Modal, Button, Typography, LinearProgress } from '@material-ui/core'
+import { grey } from '@material-ui/core/colors'
+
+const useStyles = makeStyles(theme => ({
+  modal: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  modalBody: {
+    width: 640,
+    padding: '16px 24px 24px 24px',
+    backgroundColor: grey[50],
+  },
+  text: {
+    padding: '24px 0',
+  },
+  line: {
+    height: 8,
+    borderRadius: 2,
+  },
+}))
+
+export default props => {
+  const { isLoading, isOpen, loadingText, completeText } = props
+  const classes = useStyles()
+
+  return (
+    <Modal open={isOpen} className={classes.modal}>
+      <div className={classes.modalBody}>
+        {isLoading ? (
+          <Typography>{loadingText}</Typography>
+        ) : (
+          <Typography>{completeText}</Typography>
+        )}
+        <LinearProgress
+          variant="determinate"
+          className={classes.line}
+          value={!isLoading}
+        />
+      </div>
+    </Modal>
+  )
+}

--- a/front/src/components/lv2/LoadingModal.js
+++ b/front/src/components/lv2/LoadingModal.js
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { makeStyles } from '@material-ui/styles'
-import { Modal, Button, Typography, LinearProgress } from '@material-ui/core'
+import { Modal, Typography, LinearProgress } from '@material-ui/core'
 import { grey } from '@material-ui/core/colors'
 
 const useStyles = makeStyles(theme => ({

--- a/front/src/components/lv2/LoadingModal.js
+++ b/front/src/components/lv2/LoadingModal.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { makeStyles } from '@material-ui/styles'
 import { Modal, Button, Typography, LinearProgress } from '@material-ui/core'
 import { grey } from '@material-ui/core/colors'
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
   },
   modalBody: {
     width: 640,
-    padding: '16px 24px 24px 24px',
+    padding: '40px 24px 48px',
     backgroundColor: grey[50],
   },
   text: {
@@ -20,6 +20,7 @@ const useStyles = makeStyles(theme => ({
   line: {
     height: 8,
     borderRadius: 2,
+    marginTop: 16,
   },
 }))
 
@@ -31,15 +32,21 @@ export default props => {
     <Modal open={isOpen} className={classes.modal}>
       <div className={classes.modalBody}>
         {isLoading ? (
-          <Typography>{loadingText}</Typography>
+          <div>
+            <Typography color="primary">{loadingText}</Typography>
+            <LinearProgress className={classes.line} />
+          </div>
         ) : (
-          <Typography>{completeText}</Typography>
+          <div>
+            <Typography color="secondary">{completeText}</Typography>
+            <LinearProgress
+              variant="determinate"
+              color="secondary"
+              className={classes.line}
+              value={100}
+            />
+          </div>
         )}
-        <LinearProgress
-          variant="determinate"
-          className={classes.line}
-          value={!isLoading}
-        />
       </div>
     </Modal>
   )

--- a/front/src/components/lv2/Modal.js
+++ b/front/src/components/lv2/Modal.js
@@ -14,9 +14,7 @@ const useStyles = makeStyles(theme => ({
     padding: '16px 24px 24px 24px',
     backgroundColor: grey[50],
   },
-  text: {
-    padding: '24px 0',
-  },
+  text: { padding: '24px 0' },
   buttonWrapper: {
     display: 'flex',
     justifyContent: 'flex-end',

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -83,7 +83,7 @@ export default function() {
 
   useEffect(() => {
     handlePaginate({ page: page, per: rowsPerPage })
-  }, [page, rowsPerPage])
+  })
 
   return (
     <div className={classes.root}>

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -16,9 +16,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     justifyContent: 'flex-end',
   },
-  button: {
-    width: 120,
-  },
+  button: { width: 120 },
 }))
 
 export default function(props) {
@@ -48,11 +46,6 @@ export default function(props) {
     setSelectedTiles(
       selectedTiles.map((tile, i) => (i === number - 1 ? !tile : tile))
     )
-  }
-
-  const handleLoadingToPost = () => {
-    setModalIsOpen(false)
-    setModal2IsOpen(true)
   }
 
   const handleSaveAnnotation = () => {

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -58,16 +58,20 @@ export default function(props) {
   const handleSaveAnnotation = () => {
     const handleCompleteAnnotation = response => {
       setIsPosting(false)
-      // window.location.href = '/'
+      setTimeout(() => {
+        window.location.href = '/'
+      }, 2000)
     }
     setIsPosting(true)
     setModalIsOpen(false)
     setModal2IsOpen(true)
-    // postHasLabels({
-    //   annotationId: annotation,
-    //   hasLabels: hasLabelsForPost(labels),
-    //   handleCompleteAnnotation: handleCompleteAnnotation,
-    // })
+    setTimeout(() => {
+      postHasLabels({
+        annotationId: annotation,
+        hasLabels: hasLabelsForPost(labels),
+        handleCompleteAnnotation: handleCompleteAnnotation,
+      })
+    }, 2000)
   }
 
   const handleModalOpen = () => {

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -9,6 +9,7 @@ import LabelList from 'components/lv3/LabelList'
 import KatagamiImage from 'components/lv3/KatagamiImage'
 import { initAllTiles } from 'libs/tile'
 import { hasLabelsForPost, zeroPaddingOf } from 'libs/format'
+import LoadingModal from 'components/lv2/LoadingModal'
 
 const useStyles = makeStyles(theme => ({
   submit: {
@@ -39,6 +40,8 @@ export default function(props) {
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [modalIsOpen, setModalIsOpen] = useState(false)
+  const [modal2IsOpen, setModal2IsOpen] = useState(false)
+  const [isPosting, setIsPosting] = useState(false)
 
   const handleToggleTile = number => {
     console.log(selectedTiles)
@@ -47,15 +50,24 @@ export default function(props) {
     )
   }
 
+  const handleLoadingToPost = () => {
+    setModalIsOpen(false)
+    setModal2IsOpen(true)
+  }
+
   const handleSaveAnnotation = () => {
     const handleCompleteAnnotation = response => {
-      window.location.href = '/'
+      setIsPosting(false)
+      // window.location.href = '/'
     }
-    postHasLabels({
-      annotationId: annotation,
-      hasLabels: hasLabelsForPost(labels),
-      handleCompleteAnnotation: handleCompleteAnnotation,
-    })
+    setIsPosting(true)
+    setModalIsOpen(false)
+    setModal2IsOpen(true)
+    // postHasLabels({
+    //   annotationId: annotation,
+    //   hasLabels: hasLabelsForPost(labels),
+    //   handleCompleteAnnotation: handleCompleteAnnotation,
+    // })
   }
 
   const handleModalOpen = () => {
@@ -153,6 +165,12 @@ export default function(props) {
         noText="戻る"
         handleAnswerYes={handleSaveAnnotation}
         handleAnswerNo={handleModalClose}
+      />
+      <LoadingModal
+        isLoading={isPosting}
+        isOpen={modal2IsOpen}
+        loadingText="結果を保存中です..."
+        completeText="保存が完了しました！"
       />
     </Container>
   )

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -170,7 +170,7 @@ export default function(props) {
         isLoading={isPosting}
         isOpen={modal2IsOpen}
         loadingText="結果を保存中です..."
-        completeText="保存が完了しました！"
+        completeText="保存が完了しました！ ホームに戻ります..."
       />
     </Container>
   )


### PR DESCRIPTION
## やったこと
### front
- APIとの通信中に表示するローディング用に `LoadingModal` コンポーネントを作成

<br />

## できるようになったこと
- アノテーションページにて以下の流れができる.
完了ボタン => 確認モーダルの保存ボタン => ローディング表示 => 完了 => ホームに自動遷移

![20200106-loading](https://user-images.githubusercontent.com/39250854/71794056-163a7400-3083-11ea-8b60-ea0bfc3a22e1.gif)

<br />

## やってないこと
### front
- アノテーション実行中はヘッダーのリンクが効かないようにしたい.
  - ブラウザの'戻る'も禁止したい...できるか？
  - キャンセルボタンを明示的に置く.

