### PR TITLE
ユーザーページの作成

### DIFF
--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -1,6 +1,10 @@
 class KatagamisController < ApplicationController
   def index
-    render json: cache_katagamis(params)
+    if params[:owned_user]
+      render json: cache_owned_katagamis(params)
+    else
+      render json: cache_katagamis(params)
+    end
   end
 
   def show
@@ -77,6 +81,23 @@ class KatagamisController < ApplicationController
               annotation_num: katagami.annotations.size,
               done_by_current_user: 
                 !!user_done_ids.index(katagami.id)
+            }
+          }
+        }
+      end
+    end
+
+    def cache_owned_katagamis(params)
+      Rails.cache.fetch('owned_katagamis-' + params[:page] + '-' + params[:per] + '-' + params[:owned_user]) do
+        user = User.includes(annotations: [{katagami: :annotations}]).find(params[:owned_user])
+        {
+          count: user.annotations.size,
+          katagamis: user.annotations.map {|annotation| 
+            katagami = annotation.katagami
+            {
+              id: katagami.id,
+              name: katagami.name,
+              annotation_num: katagami.annotations.size,
             }
           }
         }

--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -1,6 +1,6 @@
 class KatagamisController < ApplicationController
   def index
-    if params[:owned_user]
+    if params[:owned_user] != '0'
       render json: cache_owned_katagamis(params)
     else
       render json: cache_katagamis(params)

--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -91,6 +91,7 @@ class KatagamisController < ApplicationController
       Rails.cache.fetch('owned_katagamis-' + params[:page] + '-' + params[:per] + '-' + params[:owned_user]) do
         user = User.includes(annotations: [{katagami: :annotations}]).find(params[:owned_user])
         {
+          owned_user_email: user.email,
           count: user.annotations.size,
           katagamis: user.annotations.map {|annotation| 
             katagami = annotation.katagami

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   post '/login' , to: 'users#login'
   get 'users/:id', to: 'users#show'
   # Katagami
-  get '/katagamis/:user/:page/:per', to: 'katagamis#index'
+  get '/katagamis/:user/:page/:per/:owned_user', to: 'katagamis#index'
   get '/katagamis/:id', to: 'katagamis#show'
   # Annotation
   post '/annotations/:katagami/:user', to: 'annotations#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get 'users/:id', to: 'users#show'
   # Katagami
   get '/katagamis/:user/:page/:per', to: 'katagamis#index'
-  get '/katagamis/show/:id', to: 'katagamis#show'
+  get '/katagamis/:id', to: 'katagamis#show'
   # Annotation
   post '/annotations/:katagami/:user', to: 'annotations#create'
   post '/annotations/add_has_labels', to: 'annotations#add_has_labels'

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -17,6 +17,7 @@ import Header from 'components/lv3/Header'
 import { isAuthenticated, logout } from 'libs/auth'
 import theme from 'libs/theme'
 import ResultPage from 'pages/ResultPage'
+import UserPage from 'pages/UserPage'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -83,6 +84,7 @@ export default () => {
               component={AnnotationPage}
             />
             <PrivateRoute path="/results/:katagamiId" component={ResultPage} />
+            <PrivateRoute path="/users/:userId" component={UserPage} />
             <PrivateRoute path="/" component={TopPage} />
           </Switch>
         </Box>

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -13,7 +13,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default props => {
-  const { katagamis, emptyRows, handleSelectId } = props
+  const { katagamis, emptyRows, handleSelectId, isInUserPage } = props
   const classes = useStyles()
   return (
     <TableBody>
@@ -22,15 +22,16 @@ export default props => {
           <TableCell align="right">{katagami.id}</TableCell>
           <TableCell className={classes.name}>{katagami.name}</TableCell>
           <TableCell align="right">{katagami.annotation_num}</TableCell>
-          {katagami.done_by_current_user ? (
-            <TableCell align="center" className={classes.done}>
-              実行済
-            </TableCell>
-          ) : (
-            <TableCell align="center" className={classes.yet}>
-              未実行
-            </TableCell>
-          )}
+          {!isInUserPage &&
+            (katagami.done_by_current_user ? (
+              <TableCell align="center" className={classes.done}>
+                実行済
+              </TableCell>
+            ) : (
+              <TableCell align="center" className={classes.yet}>
+                未実行
+              </TableCell>
+            ))}
           <TableCell align="center">
             <IconButton
               className={classes.button}

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -6,6 +6,7 @@ import {
   TableCell,
   TableFooter,
   TablePagination,
+  Typography,
 } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
 import { currentUser } from 'libs/auth'
@@ -31,16 +32,18 @@ const useStyles = makeStyles(theme => ({
   },
   header: { backgroundColor: theme.palette.primary.light },
   footer: { marginTop: theme.spacing(20) },
+  profile: { marginBottom: 40 },
 }))
 
 export default props => {
-  const { ownedUser, setEmail } = props
+  const { ownedUser } = props
   const [katagamis, setKatagamis] = useState([])
   const [count, setCount] = useState(0)
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(5)
   const [selectedId, setSelectedId] = useState(0)
   const [modalIsOpen, setModalIsOpen] = useState(false)
+  const [ownedUserEmail, setOwnedUserEmail] = useState('')
   const emptyRows =
     rowsPerPage - Math.min(rowsPerPage, count - page * rowsPerPage)
   const user = currentUser()
@@ -53,7 +56,7 @@ export default props => {
       setCount(response.count)
       setPage(page)
       if (isInUserPage) {
-        setEmail(response.email)
+        setOwnedUserEmail(response.owned_user_email)
       }
     }
     fetchKatagamis({
@@ -93,21 +96,39 @@ export default props => {
 
   return (
     <div className={classes.root}>
+      {isInUserPage && (
+        <div>
+          <div className={classes.profile}>
+            <Typography variant="h2">プロフィール</Typography>
+            <Typography className={classes.email}>
+              メールアドレス : {ownedUserEmail}
+            </Typography>
+          </div>
+          <Typography variant="h2">アノテーション済みの型紙一覧</Typography>
+        </div>
+      )}
       <Table>
         <TableHead>
           <TableRow className={classes.header}>
             <TableCell align="right">id</TableCell>
             <TableCell align="left">ファイル名</TableCell>
             <TableCell align="right">アノテーション件数</TableCell>
-            <TableCell align="center">ステータス</TableCell>
+            {!isInUserPage && <TableCell align="center">ステータス</TableCell>}
             <TableCell align="center">結果一覧</TableCell>
             <TableCell align="center"></TableCell>
           </TableRow>
         </TableHead>
         <KatagamiListBody
+          {...{
+            katagamis,
+            emptyRows,
+            handleSelectId,
+            isInUserPage,
+          }}
           katagamis={katagamis}
           emptyRows={emptyRows}
           handleSelectId={handleSelectId}
+          isInUserPage={isInUserPage}
         />
         <TableFooter className={classes.footer}>
           <TableRow className={classes.tableRow}>

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -33,7 +33,8 @@ const useStyles = makeStyles(theme => ({
   footer: { marginTop: theme.spacing(20) },
 }))
 
-export default () => {
+export default props => {
+  const { ownedUser, setEmail } = props
   const [katagamis, setKatagamis] = useState([])
   const [count, setCount] = useState(0)
   const [page, setPage] = useState(0)
@@ -43,6 +44,7 @@ export default () => {
   const emptyRows =
     rowsPerPage - Math.min(rowsPerPage, count - page * rowsPerPage)
   const user = currentUser()
+  const isInUserPage = ownedUser !== undefined
   const classes = useStyles(theme)
 
   const handlePaginate = ({ page, per }) => {
@@ -50,11 +52,15 @@ export default () => {
       setKatagamis(response.katagamis)
       setCount(response.count)
       setPage(page)
+      if (isInUserPage) {
+        setEmail(response.email)
+      }
     }
     fetchKatagamis({
       userId: user.id,
       page: page + 1,
       per: per,
+      ownedUserId: isInUserPage ? ownedUser : 0,
       handleGetKatagamis: handleGetKatagamis,
     })
   }

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -43,9 +43,7 @@ export const fetchKatagamis = async props => {
   const { userId, page, per, ownedUserId, handleGetKatagamis } = props
 
   await fetchGet({
-    url: `${baseUrl}/katagamis/${userId}/${page}/${per}/${
-      ownedUserId === undefined ? 0 : ownedUserId
-    }`,
+    url: `${baseUrl}/katagamis/${userId}/${page}/${per}/${ownedUserId}`,
     successAction: handleGetKatagamis,
   })
 }

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -50,7 +50,7 @@ export const fetchKatagamis = async props => {
 export const fetchKatagamiResult = async props => {
   const { katagamiId, handleGetKatagamiResult } = props
   await fetchGet({
-    url: `${baseUrl}/katagamis/show/${katagamiId}`,
+    url: `${baseUrl}/katagamis/${katagamiId}`,
     successAction: handleGetKatagamiResult,
   })
 }

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -40,10 +40,12 @@ export const fetchUser = async props => {
 
 // Katagami
 export const fetchKatagamis = async props => {
-  const { userId, page, per, handleGetKatagamis } = props
+  const { userId, page, per, ownedUserId, handleGetKatagamis } = props
 
   await fetchGet({
-    url: `${baseUrl}/katagamis/${userId}/${page}/${per}`,
+    url: `${baseUrl}/katagamis/${userId}/${page}/${per}/${
+      ownedUserId === undefined ? 0 : ownedUserId
+    }`,
     successAction: handleGetKatagamis,
   })
 }

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -30,9 +30,10 @@ export const login = async props => {
   })
 }
 
-export const fetchUser = async (id, handleGetUser) => {
+export const fetchUser = async props => {
+  const { userId, handleGetUser } = props
   await fetchGet({
-    url: `${baseUrl}/users/${id}`,
+    url: `${baseUrl}/users/${userId}`,
     successAction: handleGetUser,
   })
 }

--- a/front/src/libs/theme.js
+++ b/front/src/libs/theme.js
@@ -19,6 +19,7 @@ const typography = {
   h2: {
     fontSize: 24,
     fontWeight: 700,
+    marginBottom: 8,
     color: palette.primary.main,
   },
   body1: {

--- a/front/src/pages/UserPage.js
+++ b/front/src/pages/UserPage.js
@@ -3,6 +3,8 @@ import { makeStyles } from '@material-ui/styles'
 import Container from 'components/lv1/Container'
 import LoadingModal from 'components/lv2/LoadingModal'
 import HeadLine from 'components/lv1/HeadLine'
+import { fetchUser } from 'libs/api'
+import { Typography } from '@material-ui/core'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -12,9 +14,23 @@ const useStyles = makeStyles(theme => ({
 
 export default props => {
   const { userId } = props.match.params
+  const [email, setEmail] = useState('')
+  const [katagamis, setKatagamis] = useState([])
+  const [annotationNum, setAnnotationNum] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
 
   const classes = useStyles()
+
+  useEffect(() => {
+    const handleGetUser = response => {
+      setEmail(response.email)
+      setKatagamis(response.katagamis)
+      setAnnotationNum(response.katagamis.length)
+      setIsLoading(false)
+    }
+    setIsLoading(true)
+    fetchUser({ userId, handleGetUser })
+  }, [userId])
 
   return isLoading ? (
     <LoadingModal
@@ -25,7 +41,8 @@ export default props => {
     />
   ) : (
     <Container>
-        <HeadLine>{userId}</HeadLine>
+      <HeadLine>{email} さん</HeadLine>
+      <Typography>累計アノテーション件数 : {annotationNum}</Typography>
     </Container>
   )
 }

--- a/front/src/pages/UserPage.js
+++ b/front/src/pages/UserPage.js
@@ -5,6 +5,8 @@ import LoadingModal from 'components/lv2/LoadingModal'
 import HeadLine from 'components/lv1/HeadLine'
 import { fetchUser } from 'libs/api'
 import { Typography } from '@material-ui/core'
+import KatagamiList from 'components/lv3/KatagamiList'
+import { zeroPaddingOf } from 'libs/format'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -14,35 +16,15 @@ const useStyles = makeStyles(theme => ({
 
 export default props => {
   const { userId } = props.match.params
-  const [email, setEmail] = useState('')
-  const [katagamis, setKatagamis] = useState([])
-  const [annotationNum, setAnnotationNum] = useState(0)
-  const [isLoading, setIsLoading] = useState(false)
+  const zeroPaddingId = zeroPaddingOf(userId, 6)
+  // const [isLoading, setIsLoading] = useState(false)
 
   const classes = useStyles()
 
-  useEffect(() => {
-    const handleGetUser = response => {
-      setEmail(response.email)
-      setKatagamis(response.katagamis)
-      setAnnotationNum(response.katagamis.length)
-      setIsLoading(false)
-    }
-    setIsLoading(true)
-    fetchUser({ userId, handleGetUser })
-  }, [userId])
-
-  return isLoading ? (
-    <LoadingModal
-      isLoading={isLoading}
-      isOpen={isLoading}
-      loadingText="データを取得中です..."
-      completeText="取得が完了しました！"
-    />
-  ) : (
+  return (
     <Container>
-      <HeadLine>{email} さん</HeadLine>
-      <Typography>累計アノテーション件数 : {annotationNum}</Typography>
+      <HeadLine>ユーザー id : {zeroPaddingId}</HeadLine>
+      <KatagamiList ownedUser={userId} />
     </Container>
   )
 }

--- a/front/src/pages/UserPage.js
+++ b/front/src/pages/UserPage.js
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from 'react'
+import { makeStyles } from '@material-ui/styles'
+import Container from 'components/lv1/Container'
+import LoadingModal from 'components/lv2/LoadingModal'
+import HeadLine from 'components/lv1/HeadLine'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    border: '1px solid',
+  },
+}))
+
+export default props => {
+  const { userId } = props.match.params
+  const [isLoading, setIsLoading] = useState(false)
+
+  const classes = useStyles()
+
+  return isLoading ? (
+    <LoadingModal
+      isLoading={isLoading}
+      isOpen={isLoading}
+      loadingText="データを取得中です..."
+      completeText="取得が完了しました！"
+    />
+  ) : (
+    <Container>
+        <HeadLine>{userId}</HeadLine>
+    </Container>
+  )
+}


### PR DESCRIPTION
## やったこと
### front
- ユーザーページの作成
- コンポーネントとして新規作成はせず, `KatagamiList` にユーザーページかどうかで表示する内容のの切り替えを加えた.
### API
- ~~`users_controller` から情報を持ってくるようにした~~
- `katagamis_controller#index` を修正して, パラメータでユーザーページの情報か判断するようにした.
<br />

## できるようになったこと
- 右上のアイコンから自分のユーザーページに飛べる.
- ユーザーページではアノテーション済みの型紙一覧が見れる.

![image](https://user-images.githubusercontent.com/39250854/71960785-37dd5c00-3239-11ea-904a-98650643387b.png)

<br />

## やってないこと
### front
- 結果ページに出てくるユーザー情報からの導線
### API
- 条件付きGETの実装
