### PR TITLE
結果ページのラベル付けしたユーザー一覧からユーザーページに飛ばす

### DIFF
--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -27,7 +27,7 @@ class KatagamisController < ApplicationController
         has_labels_by_position = katagami.annotations.map {|ant| 
           ant.has_labels.map {|has_label| 
             {
-              user: ant.user.email,
+              user: ant.user.id.to_s + ' ' + ant.user.email,
               position: has_label.position, 
               label: has_label.label.name
             }
@@ -90,10 +90,11 @@ class KatagamisController < ApplicationController
     def cache_owned_katagamis(params)
       Rails.cache.fetch('owned_katagamis-' + params[:page] + '-' + params[:per] + '-' + params[:owned_user]) do
         user = User.includes(annotations: [{katagami: :annotations}]).find(params[:owned_user])
+        annotations = user.annotations.page(params[:page]).per(params[:per])
         {
           owned_user_email: user.email,
           count: user.annotations.size,
-          katagamis: user.annotations.map {|annotation| 
+          katagamis: annotations.map {|annotation| 
             katagami = annotation.katagami
             {
               id: katagami.id,

--- a/front/src/components/lv2/UserList.js
+++ b/front/src/components/lv2/UserList.js
@@ -12,6 +12,12 @@ const useStyles = makeStyles(theme => ({
     border: props =>
       props.isActive ? `2px solid ${theme.palette.primary.light}` : 'none',
   },
+  user: {
+    cursor: 'pointer',
+    '&:hover': {
+      color: theme.palette.primary.main,
+    },
+  },
 }))
 
 export default props => {
@@ -31,7 +37,11 @@ export default props => {
           {users.map(user => {
             const [id, email] = user.split(' ')
             return (
-              <li key={id} onClick={() => handleLinkToUser(id)}>
+              <li
+                key={id}
+                className={classes.user}
+                onClick={() => handleLinkToUser(id)}
+              >
                 {email}
               </li>
             )

--- a/front/src/components/lv2/UserList.js
+++ b/front/src/components/lv2/UserList.js
@@ -19,14 +19,23 @@ export default props => {
   const isActive = activeIndex > -1
   const classes = useStyles({ isActive })
 
+  const handleLinkToUser = id => {
+    window.location.href = `/users/${id}`
+  }
+
   return (
     <Paper className={classes.root}>
       <Typography>ラベル付けしたユーザー</Typography>
       {isActive ? (
         <ul>
-          {users.map(user => (
-            <li key={user}>{user}</li>
-          ))}
+          {users.map(user => {
+            const [id, email] = user.split(' ')
+            return (
+              <li key={id} onClick={() => handleLinkToUser(id)}>
+                {email}
+              </li>
+            )
+          })}
         </ul>
       ) : (
         <Typography variant="caption">


### PR DESCRIPTION
## やったこと
### front
- アノテーション結果ページのラベル付けしたユーザー一覧にリンクを設置.
### API
- ユーザーページの型紙一覧でページネーションが効いてなかったのを修正.
<br />

## できるようになったこと
- 結果ページからラベル付けした人のページに飛べる.
<br />

## やってないこと
### front
- 文言にアイコン付けた方がいいかも
### API
- アノテーションの仕様を変更した方がいい
