### PR TITLE
アノテーションの仕様を変更

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -22,8 +22,8 @@ class AnnotationsController < ApplicationController
             position: position
           )
         end
+        new_status += 1
       end
-      new_status += 1
     end
       annotation.update(status: new_status)
       p annotation

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -7,7 +7,7 @@ class AnnotationsController < ApplicationController
     annotation = Annotation.find(params[:annotation_id])
     # {has_labels: '4 1 2 3,2 3 4,1 0'}
     # {has_labels: 'label.id [positions],label.id [position]'}
-    annotation.update(status: 1)
+    new_status = annotation.status
 
     HasLabel.transaction do
       params[:has_labels].split(',').each do |has_label|
@@ -23,8 +23,9 @@ class AnnotationsController < ApplicationController
           )
         end
       end
+      new_status += 1
     end
-      annotation.update(status: 2)
+      annotation.update(status: new_status)
       p annotation
       render json: annotation.has_labels
 

--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -63,24 +63,26 @@ class KatagamisController < ApplicationController
       Rails.cache.fetch('katagamis-' + params[:page] + '-' + params[:per]) do
         # A.ログイン中のユーザがアノテーション済みの型紙のidsを取得
         user_done_ids = Katagami.includes(annotations: [:user])
-                                .where(annotations: {status: 2, user_id: params[:user]})
-                                .pluck(:id)
+                                .where(annotations: {user_id: params[:user]})
+                                .pluck(:id, :'annotations.status')
+                                .to_h
 
         # 型紙一覧の情報 アノテーション件数を表示するためinclude
         katagamis = Katagami.includes(:annotations)
                             .page(params[:page]).per(params[:per])
+
 
         # ある型紙 x をログイン中のユーザはアノテーション済みか ?
         # => A のなかに x が入っているか ?
         {
           count: Katagami._count,
           katagamis: katagamis.map {|katagami|
+            status = user_done_ids.find {|k, v| k == katagami.id}
             {
               id: katagami.id,
               name: katagami.name,
               annotation_num: katagami.annotations.size,
-              done_by_current_user: 
-                !!user_done_ids.index(katagami.id)
+              status: status ? status[1] : 0
             }
           }
         }

--- a/app/controllers/katagamis_controller.rb
+++ b/app/controllers/katagamis_controller.rb
@@ -101,7 +101,8 @@ class KatagamisController < ApplicationController
             {
               id: katagami.id,
               name: katagami.name,
-              annotation_num: katagami.annotations.size,
+              annotation_num: katagami.annotations.sum(:status),
+              status: annotation.status
             }
           }
         }

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -12,7 +12,7 @@ class LabelsController < ApplicationController
     rest_num = 10 - annotation.status
     target_num = params[:num].to_i
 
-    if rest_label_num - target_num < 0
+    if rest_num - target_num < 0
       render json: []
     else
       render json: 

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -3,4 +3,20 @@ class LabelsController < ApplicationController
     rand_id = Label.pluck(:id).shuffle[0..2]
     render json: Label.where(id: rand_id)
   end
+
+  def target
+    annotation = Annotation.find_by(
+      katagami_id: params[:katagami],
+      user_id: params[:user]
+    )
+    rest_num = 10 - annotation.status
+    target_num = params[:num].to_i
+
+    if rest_label_num - target_num < 0
+      render json: []
+    else
+      render json: 
+        Label.where(id: [1..rest_num]).order(id: 'DESC').limit(target_num)
+    end
+  end
 end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,5 +1,5 @@
 class Annotation < ApplicationRecord
-  validates :status, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2 }
+  validates :status, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }
   validates :user_id, uniqueness: { scope: :katagami_id }
   
   belongs_to :user

--- a/app/models/has_label.rb
+++ b/app/models/has_label.rb
@@ -4,4 +4,5 @@ class HasLabel < ApplicationRecord
   belongs_to :katagami
 
   validates :position, presence: true, allow_nil: false
+  validates :position, uniqueness: { scope: [:annotation_id, :label_id] }
 end

--- a/app/models/has_label.rb
+++ b/app/models/has_label.rb
@@ -3,6 +3,8 @@ class HasLabel < ApplicationRecord
   belongs_to :annotation
   belongs_to :katagami
 
-  validates :position, presence: true, allow_nil: false
-  validates :position, uniqueness: { scope: [:annotation_id, :label_id] }
+  validates :position, 
+              presence: true, 
+              allow_nil: false, 
+              uniqueness: { scope: [:annotation_id, :label_id] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   post '/annotations/add_has_labels', to: 'annotations#add_has_labels'
   # Label
   get '/labels', to: 'labels#get_random'
+  get '/labels/target/:katagami/:user/:num', to: 'labels#target'
 end

--- a/db/migrate/20200108140015_add_uniqueness_to_has_labels.rb
+++ b/db/migrate/20200108140015_add_uniqueness_to_has_labels.rb
@@ -1,0 +1,5 @@
+class AddUniquenessToHasLabels < ActiveRecord::Migration[5.2]
+  def change
+    add_index :has_labels, [:annotation_id, :label_id, :position], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_24_093328) do
+ActiveRecord::Schema.define(version: 2020_01_08_140015) do
 
   create_table "annotations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2019_12_24_093328) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["annotation_id", "label_id", "position"], name: "index_has_labels_on_annotation_id_and_label_id_and_position", unique: true
     t.index ["annotation_id"], name: "index_has_labels_on_annotation_id"
     t.index ["katagami_id"], name: "index_has_labels_on_katagami_id"
     t.index ["label_id"], name: "index_has_labels_on_label_id"

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -80,7 +80,7 @@ export default () => {
             <AuthRoute path="/signup" component={SignupPage} />
             <AuthRoute path="/login" component={LoginPage} />
             <PrivateRoute
-              path="/ant/:katagamiId/:userId"
+              path="/ant/:katagamiId/:userId/:num"
               component={AnnotationPage}
             />
             <PrivateRoute path="/results/:katagamiId" component={ResultPage} />

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -15,23 +15,26 @@ const useStyles = makeStyles(theme => ({
 export default props => {
   const { katagamis, emptyRows, handleSelectId, isInUserPage } = props
   const classes = useStyles()
+
+  const UserStatus = ({ status }) =>
+    status === 10 ? (
+      <TableCell align="center" className={classes.done}>
+        完了
+      </TableCell>
+    ) : (
+      <TableCell align="center" className={classes.yet}>
+        {`${status} / 10`}
+      </TableCell>
+    )
+
   return (
     <TableBody>
       {katagamis.map(katagami => (
         <TableRow key={katagami.id} className={classes.tableRow}>
           <TableCell align="right">{katagami.id}</TableCell>
           <TableCell className={classes.name}>{katagami.name}</TableCell>
+          <UserStatus status={katagami.status} />
           <TableCell align="right">{katagami.annotation_num}</TableCell>
-          {!isInUserPage &&
-            (katagami.done_by_current_user ? (
-              <TableCell align="center" className={classes.done}>
-                実行済
-              </TableCell>
-            ) : (
-              <TableCell align="center" className={classes.yet}>
-                未実行
-              </TableCell>
-            ))}
           <TableCell align="center">
             <IconButton
               className={classes.button}

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -78,7 +78,7 @@ export default props => {
   }
 
   const handleDoAnnotation = () => {
-    window.location.href = `ant/${selectedId}/${user.id}`
+    window.location.href = `ant/${selectedId}/${user.id}/2`
   }
 
   const handleModalClose = () => {

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -7,6 +7,7 @@ import {
   TableFooter,
   TablePagination,
   Typography,
+  Tooltip,
 } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
 import { currentUser } from 'libs/auth'
@@ -112,8 +113,15 @@ export default props => {
           <TableRow className={classes.header}>
             <TableCell align="right">id</TableCell>
             <TableCell align="left">ファイル名</TableCell>
-            <TableCell align="right">アノテーション件数</TableCell>
-            {!isInUserPage && <TableCell align="center">ステータス</TableCell>}
+            <Tooltip
+              title="あなたがアノテーション済みのラベル数"
+              placement="top"
+            >
+              <TableCell align="center">達成度</TableCell>
+            </Tooltip>
+            <Tooltip title="達成度10のアノテーションの総数" placement="top">
+              <TableCell align="right">アノテーション件数</TableCell>
+            </Tooltip>
             <TableCell align="center">結果一覧</TableCell>
             <TableCell align="center"></TableCell>
           </TableRow>

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -82,9 +82,10 @@ export const postHasLabels = async props => {
 }
 
 // Label
-export const fetchLabels = async handleGetLabels => {
+export const fetchLabels = async props => {
+  const { userId, katagamiId, num, handleGetLabels } = props
   await fetchGet({
-    url: `${baseUrl}/labels`,
+    url: `${baseUrl}/labels/target/${katagamiId}/${userId}/${num}`,
     successAction: handleGetLabels,
   })
 }

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default props => {
-  const { userId, katagamiId } = props.match.params
+  const { userId, katagamiId, num } = props.match.params
 
   const tileNumber = 9
   const zeroPaddingId = zeroPaddingOf(katagamiId, 6)
@@ -113,11 +113,16 @@ export default props => {
       setLabels(response)
     }
     setIsLoading(true)
-    fetchLabels(handleGetLabels)
+    fetchLabels({
+      userId,
+      katagamiId,
+      handleGetLabels,
+      num,
+    })
   }, [katagamiId, userId])
 
   // init diplayedTiles (localStorage)
-  useEffect(() => initAllTiles(3), [katagamiId, userId])
+  useEffect(() => initAllTiles(num), [katagamiId, userId])
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## やったこと
### front
- 型紙一覧で表示するステータスをアノテーションしたラベル数に変更

### API
- `HasLabel`に`uniqueness`を追加してカラムが重複しないようにした.
- `Annotation.status`を単なる状態ではなく, アノテーション済みのラベル数に変更
- アノテーション時に表示するラベル数を可変(一旦2に指定)にして, 既にアノテーションしたラベルを持ってこないようにした.
<br />

## できるようになったこと
- アノテーションの達成度が一覧から確認できる.
- テーブルのヘッダを押すとTipsの説明が読める.
- ユーザーは10個全てのラベルをアノテーションするまで2個ずつアノテーションできる.

![image](https://user-images.githubusercontent.com/39250854/72001138-122b7380-3288-11ea-865b-a5a541300d4a.png)

<br />

## やってないこと
### front
- アノテーション件数の定義
- 達成度が10/10の時は編集モード or 編集不可 ?
### API
- 条件付きGET

<br />

