### PR TITLE
型紙の分割パターンを2種類から選択可能にした

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -34,7 +34,7 @@ class Annotation < ApplicationRecord
     new_status = self.status
 
     HasLabel.transaction do
-      # {has_labels: 'label_id [positions], label_id [positions]'}
+      # {has_labels: 'label_id division [positions],label_id division [positions]'}
       params[:has_labels].split(',').each do |has_label|
         self.add(has_label)
         new_status += 1
@@ -51,10 +51,11 @@ class Annotation < ApplicationRecord
   def add(has_label)
     _has_label = has_label.split(' ').map { |n| n.to_i }
     label = Label.find(_has_label.shift) # has_labelの先頭はlabel_id
+    division = _has_label.shift # その次はdivision
 
     _has_label.each {|position|
       HasLabel.create(
-        annotation: self, katagami: self.katagami, label: label, position: position
+        annotation: self, katagami: self.katagami, label: label, division: division, position: position
       )
     }
   end

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -55,23 +55,27 @@ class Katagami < ApplicationRecord
     }
   end
 
-  # ラベル名, ポジションでhas_labelをクラス分け
+  # division > position > labelでhas_labelをクラス分け
   def classified_has_labels
     annotations
       .map {|ant| 
         ant.has_labels.map {|has_label| 
           {
             user: ant.user.id.to_s + ' ' + ant.user.email,
-            position: has_label.position, 
+            position: has_label.position,
+            division: has_label.division,
             label: has_label.label.name
           }
         }
       }
-      .flatten.group_by {|label| label[:position]}
-      .map {|k, v| 
-        {
-          position: k,
-          score: v.group_by {|v| v[:label]}.each{|_, v| v.map!{|h| h[:user]}}
+      .flatten.group_by { |has_label| has_label[:division] }
+      .map {|k, v| v
+        .group_by {|label| label[:position]}
+        .map {|k, v| 
+          {
+            position: k,
+            score: v.group_by {|v| v[:label]}.each{|_, v| v.map!{|h| h[:user]}}
+          }
         }
       }
   end

--- a/db/migrate/20200113115903_add_division_to_has_labels.rb
+++ b/db/migrate/20200113115903_add_division_to_has_labels.rb
@@ -1,0 +1,5 @@
+class AddDivisionToHasLabels < ActiveRecord::Migration[5.2]
+  def change
+    add_column :has_labels, :division, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_10_155156) do
+ActiveRecord::Schema.define(version: 2020_01_13_115903) do
 
   create_table "annotations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2020_01_10_155156) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "division", null: false
     t.index ["annotation_id", "label_id", "position"], name: "index_has_labels_on_annotation_id_and_label_id_and_position", unique: true
     t.index ["annotation_id"], name: "index_has_labels_on_annotation_id"
     t.index ["katagami_id"], name: "index_has_labels_on_katagami_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,6 @@ Katagami.transaction do
       cw_obj: open(item_url)
     )
     katagami.save!
-    Katagami.add_count 1
   end
 end
 

--- a/front/src/components/lv1/DivisionSelect.js
+++ b/front/src/components/lv1/DivisionSelect.js
@@ -20,6 +20,7 @@ export default props => {
     handleChangeDivision,
     handleSelectOpen,
     handleSelectClose,
+    tileIsSelectable,
   } = props
   const classes = useStyles()
 
@@ -38,6 +39,7 @@ export default props => {
           onClose={handleSelectClose}
           value={division}
           onChange={handleChangeDivision}
+          disabled={!tileIsSelectable}
         >
           <MenuItem value={12}>4 × 3</MenuItem>
           <MenuItem value={24}>6 × 4</MenuItem>

--- a/front/src/components/lv1/DivisionSelect.js
+++ b/front/src/components/lv1/DivisionSelect.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/styles'
+import { FormControl, InputLabel, Select, MenuItem } from '@material-ui/core'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: '100%',
+    marginBottom: 24,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+  select: { width: 240 },
+}))
+
+export default props => {
+  const {
+    division,
+    selectIsOpen,
+    handleChangeDivision,
+    handleSelectOpen,
+    handleSelectClose,
+  } = props
+  const classes = useStyles()
+
+  return (
+    <div className={classes.root}>
+      <FormControl>
+        <InputLabel id="division-root-label" className={classes.input}>
+          分割数
+        </InputLabel>
+        <Select
+          labelId="division-root-label"
+          id="division-root"
+          className={classes.select}
+          open={selectIsOpen}
+          onOpen={handleSelectOpen}
+          onClose={handleSelectClose}
+          value={division}
+          onChange={handleChangeDivision}
+        >
+          <MenuItem value={12}>4 × 3</MenuItem>
+          <MenuItem value={24}>6 × 4</MenuItem>
+        </Select>
+      </FormControl>
+    </div>
+  )
+}

--- a/front/src/components/lv1/Tile.js
+++ b/front/src/components/lv1/Tile.js
@@ -9,7 +9,7 @@ const useStyles = makeStyles(theme => ({
   },
   tile: {
     color: grey[50],
-    border: '2px solid',
+    border: '1px solid',
     padding: '2px 4px',
     fontSize: 40,
   },
@@ -30,8 +30,6 @@ export default props => {
         isSelected ? classes.tile + ' ' + classes.selected : classes.tile
       }
       onClick={() => handleToggleTile(number)}
-    >
-      {number}
-    </Grid>
+    />
   )
 }

--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -17,7 +17,12 @@ import {
   Info,
 } from '@material-ui/icons'
 import { convertBoolToNumOfTiles, convertNumToBoolOfTiles } from 'libs/format'
-import { saveSelectedTiles, diplayedTiles } from 'libs/tile'
+import {
+  saveSelectedTiles,
+  displayedTiles,
+  saveDivision,
+  getDivision,
+} from 'libs/tile'
 
 const useStyles = makeStyles(theme => ({
   tiles: { paddingTop: 6 },
@@ -45,6 +50,8 @@ export default props => {
     isEditing,
     setIsEditing,
     handleToggleHint,
+    division,
+    setDivision,
   } = props
   const classes = useStyles({ ruby: name.ruby })
   const isFocused = selectedIndex === i
@@ -54,7 +61,8 @@ export default props => {
   const handleSelectThis = () => {
     if (!(isEditing || isFocused)) {
       setTileIsSelectable(false)
-      setSelectedTiles(convertNumToBoolOfTiles(diplayedTiles(i)))
+      setSelectedTiles(convertNumToBoolOfTiles(displayedTiles(i)))
+      setDivision(getDivision(i))
       setSelectedIndex(i)
     }
   }
@@ -63,14 +71,16 @@ export default props => {
     setIsEditing(false)
     setTileIsSelectable(false)
     saveSelectedTiles(convertedSelectedTiles, i)
+    saveDivision(division, i)
     setSelectedTiles(new Array(9).fill(false))
     setSelectedIndex(i + 1)
+    setDivision(getDivision(i + 1))
   }
 
   const handleEdit = () => {
     setIsEditing(true)
     setTileIsSelectable(true)
-    setSelectedTiles(convertNumToBoolOfTiles(diplayedTiles(i)))
+    setSelectedTiles(convertNumToBoolOfTiles(displayedTiles(i)))
     setSelectedIndex(i)
   }
 
@@ -82,7 +92,7 @@ export default props => {
 
   useEffect(() => {
     if (isEditingThis) {
-      setSelectedTiles(convertNumToBoolOfTiles(diplayedTiles(i)))
+      setSelectedTiles(convertNumToBoolOfTiles(displayedTiles(i)))
     }
   }, [isEditingThis, i, setSelectedTiles])
 
@@ -126,7 +136,7 @@ export default props => {
 
   const DisplayedTiles = () => (
     <Typography variant="body1" color="primary" className={classes.tiles}>
-      {isEditingThis ? convertedSelectedTiles : diplayedTiles(i)}
+      {isEditingThis ? convertedSelectedTiles : displayedTiles(i)}
     </Typography>
   )
 

--- a/front/src/components/lv2/ResultGraph.js
+++ b/front/src/components/lv2/ResultGraph.js
@@ -7,7 +7,10 @@ export default props => {
   return (
     <BarChart width={520} height={240} data={data}>
       <XAxis dataKey="label" />
-      <YAxis allowDecimals={false} />
+      <YAxis
+        allowDecimals={false}
+        domain={[0, dataMax => (dataMax ? dataMax : 1)]}
+      />
       <Bar dataKey="score" onClick={handleSelectUsers}>
         {data.map((entry, index) => (
           <Cell

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -18,20 +18,42 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
+const xDiv = division => {
+  switch (division) {
+    case 12:
+      return 3
+    case 24:
+      return 4
+    default:
+      return 3
+  }
+}
+
+const yDiv = division => {
+  switch (division) {
+    case 12:
+      return 4
+    case 24:
+      return 6
+    default:
+      return 4
+  }
+}
+
 export default props => {
   const {
     katagamiUrl,
     katagamiWidth,
     katagamiHeight,
-    tileNumber,
     selectedTiles,
     handleToggleTile,
     tileIsSelectable,
     fixedWidth,
+    division,
   } = props
   const fixedHeight = (katagamiHeight / katagamiWidth) * fixedWidth
-  const tileSquare = Math.sqrt(tileNumber)
-  const tileHeight = fixedHeight / tileSquare
+  const dx = xDiv(division)
+  const tileHeight = fixedHeight / yDiv(division)
   const savedTilesAreNotZero = selectedTiles.reduce((a, b) => a && b, true)
   const classes = useStyles({
     katagamiUrl,
@@ -44,12 +66,12 @@ export default props => {
 
   const TilesOnKatagami = () => {
     const labels = []
-    for (let i = 1; i <= tileNumber; i++) {
+    for (let i = 1; i <= division; i++) {
       labels.push(
         <Tile
           key={i}
           number={i}
-          square={tileSquare}
+          square={dx}
           isSelected={selectedTiles[i - 1]}
           handleToggleTile={handleToggleTile}
         />

--- a/front/src/components/lv3/ResultDetail.js
+++ b/front/src/components/lv3/ResultDetail.js
@@ -4,6 +4,7 @@ import { Grid, Typography } from '@material-ui/core'
 import { graphDataOf } from 'libs/format'
 import UserList from 'components/lv2/UserList'
 import ResultGraph from 'components/lv2/ResultGraph'
+import { DIVISIONS } from 'datas/tile'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -15,6 +16,7 @@ const useStyles = makeStyles(theme => ({
 export default props => {
   const {
     hasLabels,
+    division,
     wholeLabels,
     position,
     users,
@@ -22,9 +24,14 @@ export default props => {
     handleSelectUsers,
   } = props
 
-  const [hasLabel] = hasLabels.filter(
-    hasLabel => hasLabel.position === parseInt(position, 10)
-  )
+  const _has_labels = hasLabels[DIVISIONS.indexOf(division)]
+
+  const [hasLabel] = _has_labels
+    ? _has_labels.filter(
+        hasLabel => hasLabel.position === parseInt(position, 10)
+      )
+    : []
+  console.log(hasLabel)
   const data = graphDataOf(hasLabel, wholeLabels)
   const classes = useStyles()
 

--- a/front/src/datas/tile.js
+++ b/front/src/datas/tile.js
@@ -1,0 +1,3 @@
+export const MAX_DIVISION = 24
+export const DEFAULT_DIVISION = 12
+export const DIVISIONS = [12, 24]

--- a/front/src/libs/format.js
+++ b/front/src/libs/format.js
@@ -2,7 +2,6 @@ import { savedTiles } from './tile'
 
 // APIから取得したラベル名を日本語化
 export const labelNameJp = nameEn => {
-  console.log(nameEn)
   switch (nameEn) {
     case 'kasuri':
       return { kanji: '絣', ruby: 'かすり' }

--- a/front/src/libs/format.js
+++ b/front/src/libs/format.js
@@ -1,4 +1,5 @@
-import { savedTiles } from './tile'
+import { savedTiles, getDivision } from './tile'
+import { MAX_DIVISION } from 'datas/tile'
 
 // APIから取得したラベル名を日本語化
 export const labelNameJp = nameEn => {
@@ -40,7 +41,7 @@ export const convertBoolToNumOfTiles = tileStates => {
 
 // ラベル付け : レンダリング用 (String) => state (Array of Boolean)
 export const convertNumToBoolOfTiles = saveTiles => {
-  let convertArray = new Array(9).fill(false)
+  let convertArray = new Array(MAX_DIVISION).fill(false)
   if (saveTiles) {
     saveTiles
       .split(' ')
@@ -51,7 +52,9 @@ export const convertNumToBoolOfTiles = saveTiles => {
 
 // ラベル付け : 保存済み (Array of Number) => POST用 (String)
 export const hasLabelsForPost = labels =>
-  labels.map((label, i) => label.id + ' ' + savedTiles(i)).join(',')
+  labels
+    .map((label, i) => label.id + ' ' + getDivision(i) + ' ' + savedTiles(i))
+    .join(',')
 
 // idを0詰め表示
 export const zeroPaddingOf = (num, zeros) =>

--- a/front/src/libs/tile.js
+++ b/front/src/libs/tile.js
@@ -1,24 +1,41 @@
-export const initAllTiles = number => {
-  for (let i = 0; i < number; i++) saveSelectedTiles('0', i)
+// アノテーション対象のラベル数(number)だけ'0'をローカルストレージ(LS)に保存
+export const initAllTiles = (number, division) => {
+  for (let i = 0; i < number; i++) {
+    saveSelectedTiles('0', i)
+    saveDivision(division, i)
+  }
 }
 
+export const saveDivision = (division, labelNumber) => {
+  localStorage.setItem(`division${labelNumber}`, division)
+}
+
+export const getDivision = labelNumber =>
+  parseInt(localStorage.getItem(`division${labelNumber}`), 10)
+
+// アノテーション結果をLSに保存
 export const saveSelectedTiles = (tiles, labelNumber) => {
   localStorage.setItem(`label${labelNumber}`, tiles)
 }
 
+// LSに保存されたアノテーション結果を取得
 export const savedTiles = labelNumber =>
   localStorage.getItem(`label${labelNumber}`)
 
+// LSにアノテーション結果が保存され, かつ'0'=該当無しではないか
 export const tilesAreSaved = labelNumber =>
   savedTiles(labelNumber) && savedTiles(labelNumber) !== '0'
 
-export const diplayedTiles = labelNumber =>
+// レンダリング用にLSに保存されたアノテーション結果を取得
+export const displayedTiles = labelNumber =>
   tilesAreSaved(labelNumber) ? savedTiles(labelNumber) : '該当無し'
 
+// LSに保存されたアノテーション結果を削除
 export const clearTiles = labelNumber => {
   localStorage.removeItem(`label${labelNumber}`)
 }
 
+// LSに保存された全てのラベルに対するアノテーション結果を削除
 export const clearAllTiles = () => {
   console.log('* --- * --- * --- *')
   tiles()
@@ -31,5 +48,5 @@ export const clearAllTiles = () => {
 }
 
 export const tiles = () => {
-  for (let i = 0; i < 3; i++) console.log(diplayedTiles(i))
+  for (let i = 0; i < 3; i++) console.log(displayedTiles(i))
 }

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -11,6 +11,7 @@ import DivisionSelect from 'components/lv1/DivisionSelect'
 import Modal from 'components/lv2/Modal'
 import LabelList from 'components/lv3/LabelList'
 import KatagamiImage from 'components/lv3/KatagamiImage'
+import { MAX_DIVISION } from 'datas/tile'
 
 const useStyles = makeStyles(theme => ({
   submit: {
@@ -26,8 +27,6 @@ const useStyles = makeStyles(theme => ({
 
 export default props => {
   const { userId, katagamiId, num } = props.match.params
-
-  const tileNumber = 9
   const zeroPaddingId = zeroPaddingOf(katagamiId, 6)
   const classes = useStyles()
 
@@ -37,7 +36,7 @@ export default props => {
   const [katagamiHeight, setKatagamiHeight] = useState(0)
   const [labels, setLabels] = useState([])
   const [selectedTiles, setSelectedTiles] = useState(
-    new Array(tileNumber).fill(false)
+    new Array(MAX_DIVISION).fill(false)
   )
   const [tileIsSelectable, setTileIsSelectable] = useState(false)
   const [division, setDivision] = useState(12)
@@ -50,6 +49,7 @@ export default props => {
   const [isPosting, setIsPosting] = useState(false)
 
   const handleToggleTile = number => {
+    console.log(selectedTiles.length)
     setSelectedTiles(
       selectedTiles.map((tile, i) => (i === number - 1 ? !tile : tile))
     )
@@ -103,6 +103,7 @@ export default props => {
   }
 
   const handleChangeDivision = event => {
+    setSelectedTiles(new Array(MAX_DIVISION).fill(false))
     setDivision(event.target.value)
   }
 
@@ -137,8 +138,8 @@ export default props => {
     })
   }, [katagamiId, userId, num])
 
-  // init diplayedTiles (localStorage)
-  useEffect(() => initAllTiles(num), [katagamiId, userId, num, division])
+  // init displayedTiles (localStorage)
+  useEffect(() => initAllTiles(num, division), [katagamiId, userId, num])
 
   if (isLoading) {
     return (
@@ -158,6 +159,7 @@ export default props => {
           handleChangeDivision,
           handleSelectOpen,
           handleSelectClose,
+          tileIsSelectable,
         }}
       />
       <Grid container>
@@ -169,7 +171,7 @@ export default props => {
               katagamiWidth,
               tileIsSelectable,
               handleToggleTile,
-              tileNumber,
+              division,
               selectedTiles,
               fixedWidth: 640,
             }}
@@ -185,6 +187,8 @@ export default props => {
               setTileIsSelectable,
               isEditing,
               setIsEditing,
+              division,
+              setDivision,
             }}
           />
           <Grid className={classes.submit}>

--- a/front/src/pages/AnnotationPage.js
+++ b/front/src/pages/AnnotationPage.js
@@ -7,6 +7,7 @@ import { hasLabelsForPost, zeroPaddingOf } from 'libs/format'
 import Container from 'components/lv1/Container'
 import HeadLine from 'components/lv1/HeadLine'
 import LoadingModal from 'components/lv1/LoadingModal'
+import DivisionSelect from 'components/lv1/DivisionSelect'
 import Modal from 'components/lv2/Modal'
 import LabelList from 'components/lv3/LabelList'
 import KatagamiImage from 'components/lv3/KatagamiImage'
@@ -39,6 +40,8 @@ export default props => {
     new Array(tileNumber).fill(false)
   )
   const [tileIsSelectable, setTileIsSelectable] = useState(false)
+  const [division, setDivision] = useState(12)
+  const [selectIsOpen, setSelectIsOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [confirmModalIsOpen, setConfirmModalIsOpen] = useState(false)
@@ -91,6 +94,18 @@ export default props => {
     setBackModalIsOpen(false)
   }
 
+  const handleSelectOpen = () => {
+    setSelectIsOpen(true)
+  }
+
+  const handleSelectClose = () => {
+    setSelectIsOpen(false)
+  }
+
+  const handleChangeDivision = event => {
+    setDivision(event.target.value)
+  }
+
   // to fecth Katagami image
   useEffect(() => {
     const handleCreateAnnotation = response => {
@@ -123,7 +138,7 @@ export default props => {
   }, [katagamiId, userId, num])
 
   // init diplayedTiles (localStorage)
-  useEffect(() => initAllTiles(num), [katagamiId, userId, num])
+  useEffect(() => initAllTiles(num), [katagamiId, userId, num, division])
 
   if (isLoading) {
     return (
@@ -136,6 +151,15 @@ export default props => {
   return (
     <Container>
       <HeadLine>型紙 id : {zeroPaddingId}</HeadLine>
+      <DivisionSelect
+        {...{
+          division,
+          selectIsOpen,
+          handleChangeDivision,
+          handleSelectOpen,
+          handleSelectClose,
+        }}
+      />
       <Grid container>
         <Grid item xs={7}>
           <KatagamiImage

--- a/front/src/pages/ResultPage.js
+++ b/front/src/pages/ResultPage.js
@@ -5,8 +5,10 @@ import { zeroPaddingOf, convertBoolToNumOfTiles } from 'libs/format'
 import Container from 'components/lv1/Container'
 import HeadLine from 'components/lv1/HeadLine'
 import LoadingModal from 'components/lv1/LoadingModal'
+import DivisionSelect from 'components/lv1/DivisionSelect'
 import KatagamiImage from 'components/lv3/KatagamiImage'
 import ResultDetail from 'components/lv3/ResultDetail'
+import { DIVISIONS, MAX_DIVISION } from 'datas/tile'
 
 export default props => {
   const { katagamiId } = props.match.params
@@ -17,7 +19,7 @@ export default props => {
   const [katagamiWidth, setKatagamiWidth] = useState(0)
   const [katagamiHeight, setKatagamiHeight] = useState(0)
   const [selectedTiles, setSelectedTiles] = useState(
-    new Array(tileNumber).fill(false)
+    new Array(MAX_DIVISION).fill(false)
   )
   const [annotationNum, setAnnotationNum] = useState(0)
   const [wholeLabels, setWholeLabels] = useState([])
@@ -25,6 +27,8 @@ export default props => {
   const [isLoading, setIsLoading] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
   const [users, setUsers] = useState([])
+  const [division, setDivision] = useState(12)
+  const [selectIsOpen, setSelectIsOpen] = useState(false)
 
   const handleSelectUsers = (data, index) => {
     setActiveIndex(index)
@@ -37,6 +41,20 @@ export default props => {
     )
     setActiveIndex(-1)
     setUsers([])
+  }
+
+  const handleSelectOpen = () => {
+    setSelectIsOpen(true)
+  }
+
+  const handleSelectClose = () => {
+    setSelectIsOpen(false)
+  }
+
+  const handleChangeDivision = event => {
+    setSelectedTiles(new Array(MAX_DIVISION).fill(false))
+    handleToggleTile(1)
+    setDivision(event.target.value)
   }
 
   useEffect(() => {
@@ -67,6 +85,16 @@ export default props => {
   ) : (
     <Container>
       <HeadLine>型紙 id : {zeroPaddingId}</HeadLine>
+      <DivisionSelect
+        {...{
+          division,
+          selectIsOpen,
+          handleChangeDivision,
+          handleSelectOpen,
+          handleSelectClose,
+          tileIsSelectable: true,
+        }}
+      />
       <Grid container>
         <Grid item xs={6}>
           <KatagamiImage
@@ -77,7 +105,7 @@ export default props => {
               tileIsSelectable: true,
               fixedWidth: 584,
               handleToggleTile,
-              tileNumber,
+              division,
               selectedTiles,
             }}
           />
@@ -86,6 +114,7 @@ export default props => {
           <ResultDetail
             {...{
               hasLabels,
+              division,
               wholeLabels,
               users,
               activeIndex,

--- a/front/src/pages/ResultPage.js
+++ b/front/src/pages/ResultPage.js
@@ -8,12 +8,11 @@ import LoadingModal from 'components/lv1/LoadingModal'
 import DivisionSelect from 'components/lv1/DivisionSelect'
 import KatagamiImage from 'components/lv3/KatagamiImage'
 import ResultDetail from 'components/lv3/ResultDetail'
-import { DIVISIONS, MAX_DIVISION } from 'datas/tile'
+import { MAX_DIVISION } from 'datas/tile'
 
 export default props => {
   const { katagamiId } = props.match.params
   const zeroPaddingId = zeroPaddingOf(katagamiId, 6)
-  const tileNumber = 9
 
   const [katagamiUrl, setKatagamiUrl] = useState('')
   const [katagamiWidth, setKatagamiWidth] = useState(0)


### PR DESCRIPTION
## やったこと
### front, API
- 分割パターンを可変にしてアノテーションを実行するために, 仕様を広範囲において変更.
- 3 * 3 分割にしていたが, 型紙のほとんどが縦長ということで 4 * 3, 6 * 4 の2パターンを用意.

### front
- 前回と同じようなセレクトボックスの`DivisionSelect`コンポーネントを作成
  - いい感じに使い回せた気がした...
- ついでにグラフの縦軸を最大値に設定.
### API
- `HasLabel`モデルに, アノテーションした時の分割数を`division`カラムとして追加.
<br />

## できるようになったこと
- アノテーション実行時に分割パターンを必要に応じて変更できる.
- 結果ページでも, 分割パターン毎の結果が確認できる.

![200114-division-2](https://user-images.githubusercontent.com/39250854/72275790-f6521400-3671-11ea-8968-5b2b92a3b06b.gif)

<br />

## やってないこと
### front
- 結果ページをもっと親切にできる気がする...
### API
- `katagami.ant_num`をインクリメントするタイミングが間違ってる.
- レスポンス丸々のキャッシュ.
