### PR TITLE
レスポンスのキャッシュとロジック修正

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -34,6 +34,7 @@ class Annotation < ApplicationRecord
     end
       self.katagami.plus_ant_num if self.status == 0
       self.update(status: new_status)
+      katagami.clear_caches
       self.has_labels
     rescue => e
       p e.message

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -23,19 +23,19 @@ class Annotation < ApplicationRecord
 
   # アノテーション結果を保存
   def save_result(params)
-    new_status = self.status
+    new_status = status
 
     HasLabel.transaction do
       # {has_labels: 'label_id division [positions],label_id division [positions]'}
       params[:has_labels].split(',').each do |has_label|
-        self.add(has_label)
+        add(has_label)
         new_status += 1
       end
     end
-      self.katagami.plus_ant_num if self.status == 0
-      self.update(status: new_status)
+      katagami.plus_ant_num if status == 0
+      update(status: new_status)
       katagami.clear_caches
-      self.has_labels
+      has_labels
     rescue => e
       p e.message
       []
@@ -49,7 +49,7 @@ class Annotation < ApplicationRecord
 
     _has_label.each {|position|
       HasLabel.create(
-        annotation: self, katagami: self.katagami, label: label, division: division, position: position
+        annotation: self, katagami: katagami, label: label, division: division, position: position
       )
     }
   end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -10,16 +10,8 @@ class Annotation < ApplicationRecord
   # アノテーション実行開始
   def self.stand_by(params)
     katagami = Katagami.find(params[:katagami])
-    ant_params = {
-      katagami: katagami,
-      user: User.find(params[:user])
-    }
-    annotation = find_by(ant_params)
-
-    if !annotation.present?
-      annotation = create(ant_params)
-      katagami.update(ant_num: katagami.ant_num + 1)
-    end
+    ant_params = { katagami: katagami, user: User.find(params[:user])}
+    annotation = find_by(ant_params) || create(ant_params) 
     
     {
       id: annotation.id,
@@ -40,6 +32,7 @@ class Annotation < ApplicationRecord
         new_status += 1
       end
     end
+      self.katagami.plus_ant_num if self.status == 0
       self.update(status: new_status)
       self.has_labels
     rescue => e

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -80,6 +80,10 @@ class Katagami < ApplicationRecord
       }
   end
 
+  def plus_ant_num(n=1)
+    self.update(ant_num: self.ant_num + n)
+  end
+
   def self.s3_bucket
     Aws::S3::Resource.new(
       region: 'ap-northeast-1',

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -19,26 +19,30 @@ class Katagami < ApplicationRecord
 
   # トップページの型紙一覧
   def self.listing_for_top(params)
-    katagamis = Katagami.all.pluck(:id, :name, :ant_num)
-    statuses = ant_statuses(params[:user])
+    Rails.cache.fetch('katagamis-' + params[:user] + params[:page] + params[:per] + params[:sorting]) do
+      katagamis = Katagami.all.pluck(:id, :name, :ant_num)
+      statuses = ant_statuses(params[:user])
 
-    top = (params[:page].to_i - 1) * params[:per].to_i
-    bottom = top + params[:per].to_i - 1
-    sortIndex = params[:sorting].to_i
+      top = (params[:page].to_i - 1) * params[:per].to_i
+      bottom = top + params[:per].to_i - 1
+      sortIndex = params[:sorting].to_i
 
-    katagamis
-      .map  {|k| k << (statuses[k[0]] ? statuses[k[0]] : 0)}
-      .sort {|a, b| a[sortIndex] <=> b[sortIndex]}[top..bottom]
-      .format_for_index(katagamis.size)
+      katagamis
+        .map  {|k| k << (statuses[k[0]] ? statuses[k[0]] : 0)}
+        .sort {|a, b| a[sortIndex] <=> b[sortIndex]}[top..bottom]
+        .format_for_index(katagamis.size)
+    end
   end
 
   # ユーザーページの型紙一覧
   def self.listing_for_user(params)
-    includes(:annotations)
-      .where(annotations: {user_id: params[:owned_user]}).order(:id)
-      .page(params[:page]).per(params[:per])
-      .pluck(:id, :name, :ant_num, :'annotations.status')
-      .format_for_index
+    Rails.cache.fetch('katagamis-owned-' + params[:page] + params[:per] + params[:owned_user]) do
+      includes(:annotations)
+        .where(annotations: {user_id: params[:owned_user]}).order(:id)
+        .page(params[:page]).per(params[:per])
+        .pluck(:id, :name, :ant_num, :'annotations.status')
+        .format_for_index
+    end
   end
 
   # アノテーション結果ページのリソース
@@ -57,31 +61,41 @@ class Katagami < ApplicationRecord
 
   # division > position > labelでhas_labelをクラス分け
   def classified_has_labels
-    annotations
-      .map {|ant| 
-        ant.has_labels.map {|has_label| 
-          {
-            user: ant.user.id.to_s + ' ' + ant.user.email,
-            position: has_label.position,
-            division: has_label.division,
-            label: has_label.label.name
+    Rails.cache.fetch('has_labels-' + id.to_s) do
+      annotations
+        .map {|ant| 
+          ant.has_labels.map {|has_label| 
+            {
+              user: ant.user.id.to_s + ' ' + ant.user.email,
+              position: has_label.position,
+              division: has_label.division,
+              label: has_label.label.name
+            }
           }
         }
-      }
-      .flatten.group_by { |has_label| has_label[:division] }
-      .map {|k, v| v
-        .group_by {|label| label[:position]}
-        .map {|k, v| 
-          {
-            position: k,
-            score: v.group_by {|v| v[:label]}.each{|_, v| v.map!{|h| h[:user]}}
+        .flatten.group_by { |has_label| has_label[:division] }
+        .map {|k, v| v
+          .group_by {|label| label[:position]}
+          .map {|k, v| 
+            {
+              position: k,
+              score: v.group_by {|v| v[:label]}.each{|_, v| v.map!{|h| h[:user]}}
+            }
           }
         }
-      }
+    end
+  end
+
+   # 型紙一覧の全キャッシュと自身の持つHasLabelのキャッシュをクリア
+   def clear_caches
+    Rails.cache.instance_variable_get(:@data).keys.each {|k| 
+      Rails.cache.delete(k) if k.match(/katagamis/)
+    }
+    Rails.cache.delete('has_labels-' + id.to_s)
   end
 
   def plus_ant_num(n=1)
-    self.update(ant_num: self.ant_num + n)
+    self.update(ant_num: ant_num + n)
   end
 
   def self.s3_bucket

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -95,7 +95,7 @@ class Katagami < ApplicationRecord
   end
 
   def plus_ant_num(n=1)
-    self.update(ant_num: ant_num + n)
+    update(ant_num: ant_num + n)
   end
 
   def self.s3_bucket

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -5,7 +5,7 @@ class Label < ApplicationRecord
 
   def self.listing
     Rails.cache.fetch('labels') do
-      Label.all.pluck(:name)
+      all.pluck(:name)
     end
   end
 
@@ -15,6 +15,6 @@ class Label < ApplicationRecord
     target_num = params[:num].to_i
 
     rest_num - target_num < 0 ?
-      [] : Label.where(id: [1..rest_num]).order(id: 'DESC').limit(target_num)
+      [] : where(id: [1..rest_num]).order(id: 'DESC').limit(target_num)
   end
 end


### PR DESCRIPTION
## やったこと
### API
- `katagami.ant_num`の更新タイミングを修正
- レスポンスのキャッシュを実装.
  - 条件付きGETは使わず, アノテーション結果を保存するタイミングで関連するキャッシュをクリアするようにした.
<br />

## できるようになったこと
- キャッシュ.
<br />

## やってないこと
