### PR TITLE
Productionでのid10飛ばしへの対応 (Label) + α

### DIFF
--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -11,11 +11,13 @@ class Label < ApplicationRecord
   
     def listing_for_ant(params, user_id)
       annotation = Annotation.find_by(katagami_id: params[:katagami], user_id: user_id)
+
       head = annotation ? annotation.status : 0
       tail = head + params[:num].to_i - 1
   
       head === 10 ? 
-        [] : all.pluck(:id, :name)[head..tail].map {|l| { id: l[0], name: l[1] }}
+        [] : all.pluck(:id, :name)[head..tail]
+                .map.with_index {|l, i| { id: head + 1 + i, name: l[1] }}
     end
   end
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -2,18 +2,20 @@ class Label < ApplicationRecord
   validates :name, presence: true, allow_nil: false
   has_many :has_labels
 
-  def self.listing
-    Rails.cache.fetch('labels') do
-      all.pluck(:name)
+  class << self
+    def listing
+      Rails.cache.fetch('labels') do
+        all.pluck(:name)
+      end
     end
-  end
-
-  def self.listing_for_ant(params, user_id)
-    annotation = Annotation.find_by(katagami_id: params[:katagami], user_id: user_id)
-    rest_num = annotation ? 10 - annotation.status : 10
-    target_num = params[:num].to_i
-
-    rest_num - target_num < 0 ?
-      [] : where(id: [1..rest_num]).order(id: 'DESC').limit(target_num)
+  
+    def listing_for_ant(params, user_id)
+      annotation = Annotation.find_by(katagami_id: params[:katagami], user_id: user_id)
+      head = annotation ? annotation.status : 0
+      tail = head + params[:num].to_i - 1
+  
+      head === 10 ? 
+        [] : all.pluck(:id, :name)[head..tail].map {|l| { id: l[0], name: l[1] }}
+    end
   end
 end

--- a/front/src/components/lv1/LabelHint.js
+++ b/front/src/components/lv1/LabelHint.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles(theme => ({
 export default props => {
   const { check, index, handleClose } = props
   const classes = useStyles()
-  const hintData = labelInfo[index ? index - 1 : 0]
+  const hintData = labelInfo[index]
   return (
     <div className={classes.root}>
       <Fade in={check}>

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -65,7 +65,7 @@ export default props => {
         </TableRow>
       ))}
       {emptyRows > 0 && (
-        <TableRow style={{ height: 55 * emptyRows }}>
+        <TableRow style={{ height: 65 * emptyRows }}>
           <TableCell colSpan={6} />
         </TableRow>
       )}

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -4,6 +4,10 @@ import { Grid } from '@material-ui/core'
 import Tile from 'components/lv1/Tile'
 
 const useStyles = makeStyles(theme => ({
+  wrapper: {
+    overflow: 'scroll',
+    height: 640,
+  },
   root: {
     width: props => `${props.fixedWidth}px`,
     pointerEvents: props => (props.tileIsSelectable ? '' : 'none'),
@@ -81,10 +85,12 @@ export default props => {
   }
 
   return (
-    <div className={classes.root}>
-      <Grid container spacing={0} className={classes.katagami}>
-        <TilesOnKatagami />
-      </Grid>
+    <div className={classes.wrapper}>
+      <div className={classes.root}>
+        <Grid container spacing={0} className={classes.katagami}>
+          <TilesOnKatagami />
+        </Grid>
+      </div>
     </div>
   )
 }

--- a/front/src/components/lv3/LabelList.js
+++ b/front/src/components/lv3/LabelList.js
@@ -48,7 +48,7 @@ export default props => {
       </div>
       <LabelHint
         check={hintIsOpen}
-        index={labels.length > 0 ? labels[0].id - selectedIndex : selectedIndex}
+        index={labels.length > 0 ? labels[selectedIndex].id - 1 : 0}
         handleClose={handleCloseHint}
       />
     </div>

--- a/front/src/libs/api.js
+++ b/front/src/libs/api.js
@@ -1,7 +1,4 @@
-const baseUrl =
-  process.env.NODE_ENV === 'production'
-    ? process.env.REACT_APP_PROD_API_URL
-    : process.env.REACT_APP_DEV_API_URL
+const baseUrl = process.env.REACT_APP_API_URL
 
 // Auth失効時のリダイレクト
 export const redirectToWelcome = () =>


### PR DESCRIPTION
##  やったこと#33 
### front
- 環境変数の記述形式をproductionと合わせた.
- `LabelHint`が受け取る`index`を修正
- `KatagamiImage`に`height`を指定
  - `over-flow: scroll` に設定
- `KatagamiList` の空行の`height`を修正
### API
- `Label.listing_for_ant`を`id`の値をそのまま使わない方法に修正.
<br />

## できるようになったこと
- develop, production 両方で正しいラベルのヒントが確認できる.
<br />

## やってないこと
### front
- #34 



