### PR TITLE
ブラウザの戻るボタンを使った場合の誤動作に対応

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,6 +12,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def after_omniauth_failure_path_for resources
+    root_path
+  end
+
   private
     def payload(user)
       return nil unless user && user.id

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -45,7 +45,7 @@ export default () => {
         />
       )
     }
-    // redirectToWelcome()
+    redirectToWelcome()
     return
   }
 

--- a/front/src/pages/AuthPage.js
+++ b/front/src/pages/AuthPage.js
@@ -3,11 +3,12 @@ import { useHistory, Redirect } from 'react-router-dom'
 
 export default props => {
   const { authorization, handleSignIn, auth } = props
+  const history = useHistory()
 
   if (auth) {
-    const history = useHistory()
     history.replace({ pathname: '/' })
   } else {
+    history.push('/')
     handleSignIn(authorization)
   }
 


### PR DESCRIPTION
## 🍔やったこと
### front
- サインイン時に`history.push('/')`を追加して, 戻るボタンでgoogleの画面に飛ばないようにした.
### API
- それでももう一回戻ったらgoogleの画面に飛ぶので, そこで認証しようとすると`csrf_detected`でエラーになるので, その際の遷移先である`omniauth_failuer_path`をwelcomeページに設定した.
<br />

## 🍣できるようになったこと
- サインアウト後に戻るボタン押したらサインイン状態のページに戻れるバグがなくなる.
- 戻るボタンで出てきたgoogleの画面での認証は失敗して, welcomeページに戻る.
<br />

## 🍜やってないこと
### front
- 失敗しましたよ的なメッセージを出した方が親切かも.
> 戻るボタンで出てきたgoogleの画面での認証は失敗して, welcomeページに戻る.
<br />