### PR TITLE
分割数のバージョンアップ, ラベルのレイアウト修正とpropTypesの導入

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -8,6 +8,7 @@
     "@material-ui/lab": "^4.0.0-alpha.38",
     "jshint": "^2.10.3",
     "prettier": "^1.19.1",
+    "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-cookie": "^4.0.3",
     "react-dom": "^16.12.0",

--- a/front/src/components/lv1/ActivatedAntButtons.js
+++ b/front/src/components/lv1/ActivatedAntButtons.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { makeStyles } from '@material-ui/styles'
+import { IconButton } from '@material-ui/core'
+import { Edit, Cancel, Check } from '@material-ui/icons'
+
+const useStyles = makeStyles(theme => ({
+  buttons: { width: 128 },
+  single: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
+}))
+
+const ActivatedAntButtons = props => {
+  const {
+    isEditingThis,
+    isFocused,
+    handleSave,
+    handleEdit,
+    handleCancelEdit,
+  } = props
+  const classes = useStyles()
+
+  if (isEditingThis) {
+    return (
+      <div classes={classes.buttons}>
+        <IconButton color="primary" onClick={handleSave}>
+          <Check />
+        </IconButton>
+        <IconButton color="secondary" onClick={handleCancelEdit}>
+          <Cancel />
+        </IconButton>
+      </div>
+    )
+  }
+  return (
+    <div className={classes.buttons + ' ' + classes.single}>
+      <IconButton color="default" onClick={handleEdit} disabled={!isFocused}>
+        <Edit />
+      </IconButton>
+    </div>
+  )
+}
+
+ActivatedAntButtons.propTypes = {
+  isEditingThis: PropTypes.bool,
+  isFocused: PropTypes.bool,
+  handleSave: PropTypes.func,
+  handleEdit: PropTypes.func,
+  handleCancelEdit: PropTypes.func,
+}
+
+export default ActivatedAntButtons

--- a/front/src/components/lv1/DivisionSelect.js
+++ b/front/src/components/lv1/DivisionSelect.js
@@ -42,7 +42,8 @@ export default props => {
           disabled={!tileIsSelectable}
         >
           <MenuItem value={12}>4 × 3</MenuItem>
-          <MenuItem value={24}>6 × 4</MenuItem>
+          <MenuItem value={48}>8 × 6</MenuItem>
+          <MenuItem value={192}>16 × 12</MenuItem>
         </Select>
       </FormControl>
     </div>

--- a/front/src/components/lv1/RubyLabelName.js
+++ b/front/src/components/lv1/RubyLabelName.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Typography, IconButton } from '@material-ui/core'
+import { Info } from '@material-ui/icons'
+import { makeStyles } from '@material-ui/styles'
+
+const useStyles = makeStyles(theme => ({
+  hint: {
+    padding: 0,
+    lineHeight: 16,
+    margin: '0 0 6px 4px',
+  },
+}))
+
+const RubyLabelName = props => {
+  const { name, isFocused, handleToggleHint } = props
+  const classes = useStyles()
+
+  return (
+    <Typography>
+      <ruby>
+        {name.kanji}
+        <rt>{name.ruby}</rt>
+      </ruby>
+      <IconButton
+        disabled={!isFocused}
+        onClick={handleToggleHint}
+        className={classes.hint}
+      >
+        <Info fontSize="small" />
+      </IconButton>
+    </Typography>
+  )
+}
+
+RubyLabelName.propTypes = {
+  name: PropTypes.shape({
+    kanji: PropTypes.string.isRequired,
+    ruby: PropTypes.string.isRequired,
+  }).isRequired,
+  isFocused: PropTypes.bool.isRequired,
+  handleToggleHint: PropTypes.func.isRequired,
+}
+
+export default RubyLabelName

--- a/front/src/components/lv1/RubyLabelName.js
+++ b/front/src/components/lv1/RubyLabelName.js
@@ -5,10 +5,16 @@ import { Info } from '@material-ui/icons'
 import { makeStyles } from '@material-ui/styles'
 
 const useStyles = makeStyles(theme => ({
+  root: {
+    width: 96,
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
   hint: {
     padding: 0,
     lineHeight: 16,
-    margin: '0 0 6px 4px',
+    marginLeft: 4,
   },
 }))
 
@@ -17,7 +23,7 @@ const RubyLabelName = props => {
   const classes = useStyles()
 
   return (
-    <Typography>
+    <Typography className={classes.root}>
       <ruby>
         {name.kanji}
         <rt>{name.ruby}</rt>

--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -4,17 +4,10 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  IconButton,
   Grid,
   Typography,
 } from '@material-ui/core'
-import {
-  RadioButtonUnchecked,
-  RadioButtonChecked,
-  Edit,
-  Cancel,
-  Check,
-} from '@material-ui/icons'
+import { RadioButtonUnchecked, RadioButtonChecked } from '@material-ui/icons'
 import { convertBoolToNumOfTiles, convertNumToBoolOfTiles } from 'libs/format'
 import {
   saveSelectedTiles,
@@ -23,14 +16,10 @@ import {
   getDivision,
 } from 'libs/tile'
 import RubyLabelName from 'components/lv1/RubyLabelName'
+import ActivatedAntButtons from 'components/lv1/ActivatedAntButtons'
 
 const useStyles = makeStyles(theme => ({
   tiles: { paddingTop: 6 },
-  buttons: { width: 128 },
-  single: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-  },
 }))
 
 export default props => {
@@ -91,28 +80,6 @@ export default props => {
     }
   }, [isEditingThis, i, setSelectedTiles])
 
-  const ActivatedButtons = () => {
-    if (isEditingThis) {
-      return (
-        <div classes={classes.buttons}>
-          <IconButton color="primary" onClick={handleSave}>
-            <Check />
-          </IconButton>
-          <IconButton color="secondary" onClick={handleCancelEdit}>
-            <Cancel />
-          </IconButton>
-        </div>
-      )
-    }
-    return (
-      <div className={classes.buttons + ' ' + classes.single}>
-        <IconButton color="default" onClick={handleEdit} disabled={!isFocused}>
-          <Edit />
-        </IconButton>
-      </div>
-    )
-  }
-
   const DisplayedTiles = () => (
     <Typography variant="body1" color="primary" className={classes.tiles}>
       {isEditingThis ? convertedSelectedTiles : displayedTiles(i)}
@@ -138,7 +105,15 @@ export default props => {
           </Grid>
         </Grid>
       </ListItemText>
-      <ActivatedButtons />
+      <ActivatedAntButtons
+        {...{
+          isEditingThis,
+          isFocused,
+          handleSave,
+          handleEdit,
+          handleCancelEdit,
+        }}
+      />
     </ListItem>
   )
 }

--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -1,14 +1,13 @@
 import React, { useEffect } from 'react'
 import { makeStyles } from '@material-ui/styles'
+import { RadioButtonUnchecked, RadioButtonChecked } from '@material-ui/icons'
+import { convertBoolToNumOfTiles, convertNumToBoolOfTiles } from 'libs/format'
 import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Grid,
   Typography,
 } from '@material-ui/core'
-import { RadioButtonUnchecked, RadioButtonChecked } from '@material-ui/icons'
-import { convertBoolToNumOfTiles, convertNumToBoolOfTiles } from 'libs/format'
 import {
   saveSelectedTiles,
   displayedTiles,
@@ -19,7 +18,18 @@ import RubyLabelName from 'components/lv1/RubyLabelName'
 import ActivatedAntButtons from 'components/lv1/ActivatedAntButtons'
 
 const useStyles = makeStyles(theme => ({
-  tiles: { paddingTop: 6 },
+  textWrapper: {
+    width: 300,
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  tiles: {
+    lineHeight: '48px',
+    overflowX: 'scroll',
+    display: 'inline-block',
+    whiteSpace: 'nowrap',
+  },
 }))
 
 export default props => {
@@ -80,12 +90,6 @@ export default props => {
     }
   }, [isEditingThis, i, setSelectedTiles])
 
-  const DisplayedTiles = () => (
-    <Typography variant="body1" color="primary" className={classes.tiles}>
-      {isEditingThis ? convertedSelectedTiles : displayedTiles(i)}
-    </Typography>
-  )
-
   return (
     <ListItem selected={isFocused}>
       <ListItemIcon onClick={handleSelectThis}>
@@ -96,14 +100,12 @@ export default props => {
         )}
       </ListItemIcon>
       <ListItemText>
-        <Grid container>
-          <Grid item xs={4} className={classes.name}>
-            <RubyLabelName {...{ name, isFocused, handleToggleHint }} />
-          </Grid>
-          <Grid item xs={4} className={classes.tile}>
-            <DisplayedTiles />
-          </Grid>
-        </Grid>
+        <div className={classes.textWrapper}>
+          <RubyLabelName {...{ name, isFocused, handleToggleHint }} />
+          <Typography variant="body1" color="primary" className={classes.tiles}>
+            {isEditingThis ? convertedSelectedTiles : displayedTiles(i)}
+          </Typography>
+        </div>
       </ListItemText>
       <ActivatedAntButtons
         {...{

--- a/front/src/components/lv2/Label.js
+++ b/front/src/components/lv2/Label.js
@@ -14,7 +14,6 @@ import {
   Edit,
   Cancel,
   Check,
-  Info,
 } from '@material-ui/icons'
 import { convertBoolToNumOfTiles, convertNumToBoolOfTiles } from 'libs/format'
 import {
@@ -23,6 +22,7 @@ import {
   saveDivision,
   getDivision,
 } from 'libs/tile'
+import RubyLabelName from 'components/lv1/RubyLabelName'
 
 const useStyles = makeStyles(theme => ({
   tiles: { paddingTop: 6 },
@@ -30,11 +30,6 @@ const useStyles = makeStyles(theme => ({
   single: {
     display: 'flex',
     justifyContent: 'flex-end',
-  },
-  hint: {
-    padding: 0,
-    lineHeight: 16,
-    margin: '0 0 6px 4px',
   },
 }))
 
@@ -118,22 +113,6 @@ export default props => {
     )
   }
 
-  const RubyLabelName = () => (
-    <Typography>
-      <ruby>
-        {name.kanji}
-        <rt>{name.ruby}</rt>
-      </ruby>
-      <IconButton
-        disabled={!isFocused}
-        onClick={handleToggleHint}
-        className={classes.hint}
-      >
-        <Info fontSize="small" />
-      </IconButton>
-    </Typography>
-  )
-
   const DisplayedTiles = () => (
     <Typography variant="body1" color="primary" className={classes.tiles}>
       {isEditingThis ? convertedSelectedTiles : displayedTiles(i)}
@@ -152,7 +131,7 @@ export default props => {
       <ListItemText>
         <Grid container>
           <Grid item xs={4} className={classes.name}>
-            <RubyLabelName />
+            <RubyLabelName {...{ name, isFocused, handleToggleHint }} />
           </Grid>
           <Grid item xs={4} className={classes.tile}>
             <DisplayedTiles />

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { makeStyles } from '@material-ui/styles'
 import { Grid } from '@material-ui/core'
 import Tile from 'components/lv1/Tile'
+import { DIV_X, DIV_Y } from 'datas/tile'
 
 const useStyles = makeStyles(theme => ({
   wrapper: {
@@ -22,28 +23,6 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const xDiv = division => {
-  switch (division) {
-    case 12:
-      return 3
-    case 24:
-      return 4
-    default:
-      return 3
-  }
-}
-
-const yDiv = division => {
-  switch (division) {
-    case 12:
-      return 4
-    case 24:
-      return 6
-    default:
-      return 4
-  }
-}
-
 export default props => {
   const {
     katagamiUrl,
@@ -56,8 +35,8 @@ export default props => {
     division,
   } = props
   const fixedHeight = (katagamiHeight / katagamiWidth) * fixedWidth
-  const dx = xDiv(division)
-  const tileHeight = fixedHeight / yDiv(division)
+  const dx = DIV_X(division)
+  const tileHeight = fixedHeight / DIV_Y(division)
   const savedTilesAreNotZero = selectedTiles.reduce((a, b) => a && b, true)
   const classes = useStyles({
     katagamiUrl,

--- a/front/src/components/lv3/LabelList.js
+++ b/front/src/components/lv3/LabelList.js
@@ -49,7 +49,7 @@ export default props => {
       <LabelHint
         check={hintIsOpen}
         index={
-          labels.length > 0 && labels.length < selectedIndex
+          labels.length > 0 && selectedIndex < labels.length
             ? labels[selectedIndex].id - 1
             : 0
         }

--- a/front/src/datas/tile.js
+++ b/front/src/datas/tile.js
@@ -1,3 +1,29 @@
-export const MAX_DIVISION = 24
-export const DEFAULT_DIVISION = 12
-export const DIVISIONS = [12, 24]
+export const DIVISIONS = [12, 48, 192]
+export const MAX_DIVISION = DIVISIONS[DIVISIONS.length - 1]
+export const DEFAULT_DIVISION = DIVISIONS[0]
+
+export const DIV_X = division => {
+  switch (division) {
+    case 12:
+      return 3
+    case 48:
+      return 6
+    case 192:
+      return 12
+    default:
+      return 3
+  }
+}
+
+export const DIV_Y = division => {
+  switch (division) {
+    case 12:
+      return 4
+    case 48:
+      return 8
+    case 192:
+      return 16
+    default:
+      return 4
+  }
+}


### PR DESCRIPTION
## 🍔 やったこと
### front
- 型紙画像の分割数の段階を変更.
  - before : [4 × 3], [6 × 4]
  - after : [4 × 3], [8 × 6], [16 × 12]
- `Label`のレイアウトを修正.
  - ついでに`RubyLabelName`, `ActivatedAntButtons`を別ファイルに分割.
- `propTypes`を導入. 新規作成するコンポーネントは積極的に使っていきたい.
<br />

## 🍣 できるようになったこと
- アノテーション画面がこんな感じになる.

![image](https://user-images.githubusercontent.com/39250854/73594220-adde9580-454f-11ea-980c-a58b0059bbf6.png)

<br />

## 🍕 やってないこと
### front,  API
- #36 
<br />