### PR TITLE
トップページアクセス時におすすめアノテーション実行への導線を設置

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -1,11 +1,8 @@
 class AnnotationsController < ApplicationController
   def create
-    render json: Annotation.stand_by(params[:katagami], current_user.id)
-  end
-
-  def create_with_recommend
     render json: Annotation.stand_by(
-      current_user.recommended_katagami_id,
+      params[:katagami] == 'recommend' ? 
+        current_user.recommended_katagami_id : params[:katagami], 
       current_user.id
     )
   end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -3,6 +3,13 @@ class AnnotationsController < ApplicationController
     render json: Annotation.stand_by(params[:katagami], current_user.id)
   end
 
+  def create_with_recommend
+    render json: Annotation.stand_by(
+      current_user.recommended_katagami_id,
+      current_user.id
+    )
+  end
+
   def add_has_labels
     render json: 
       Annotation.find(params[:annotation_id]).save_result(params)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     
     if @user.persisted?
       sign_in @user
-      redirect_to ENV['FRONT_URL'] + 'auth/' + payload(@user)[:auth_token] + '/' + @user.have_done_all_annotations
+      redirect_to ENV['FRONT_URL'] + 'auth/' + payload(@user)[:auth_token] + '/' + (@user.have_done_all_annotations? ? '0' : '1')
     else
       redirect_to root_path
     end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     
     if @user.persisted?
       sign_in @user
-      redirect_to ENV['FRONT_URL'] + 'auth/' + payload(@user)[:auth_token]
+      redirect_to ENV['FRONT_URL'] + 'auth/' + payload(@user)[:auth_token] + '/' + @user.have_done_all_annotations
     else
       redirect_to root_path
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   end
 
   def have_done_all_annotations?
-    (Katagami.all.pluck(:id) - annotations.pluck(:katagami_id, :status).select {|a| i[a] == 10}.to_h.keys).size < 0
+    (Katagami.all.pluck(:id) - annotations.pluck(:katagami_id, :status).select {|a| a[1] == 10}.to_h.keys).size < 0
   end
 
   def recommended_katagami_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
     Rails.cache.fetch('user-' + id.to_s) do
       user = User.includes(:annotations).find(id)
       annotations = user.annotations.pluck(:id, :status)
-      doing = annotations.select {|a| a[1].between?(1, 9)}.size
-      done = annotations.select {|a| a[1] == 10}.size
+      doing = annotations.count {|a| a[1].between?(1, 9)}
+      done = annotations.count {|a| a[1] == 10}
 
       {
         id: id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,19 +8,30 @@ class User < ApplicationRecord
   def self.detail(id)
     Rails.cache.fetch('user-' + id.to_s) do
       user = User.includes(:annotations).find(id)
-      annotations = user.annotations.pluck(:id, :status)
-      doing = annotations.count {|a| a[1].between?(1, 9)}
-      done = annotations.count {|a| a[1] == 10}
+      done, doing = user.annotations.pluck(:id, :status).partition {|a| a[1] == 10}
 
       {
         id: id,
         email: user.email,
         ant_counts: [
-          { status: 'DOING', count: doing },
-          { status: 'DONE',  count: done },
-          { status: 'YET',   count: Katagami.count - (doing + done) }
+          { status: 'DOING', count: doing.size },
+          { status: 'DONE',  count: done.size },
+          { status: 'YET',   count: Katagami.count - (doing.size + done.size) }
         ]
       }
+    end
+  end
+
+  def recommended_katagami_id
+    all_ids = Katagami.all.pluck(:id)
+    doing_or_done_statuses = annotations.pluck(:katagami_id, :status).to_h
+    yet_ids = all_ids - doing_or_done_statuses.keys
+
+    if yet_ids.size > 0
+      yet_ids[0]
+    else
+      recommend = doing_or_done_statuses.sort {|a, b| a[1] <=> b[1]}[0]
+      recommend[1] == 10 ? -1 : recommend[0]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Rails.application.routes.draw do
   # Annotation
   post '/annotations/add_has_labels', to: 'annotations#add_has_labels'
   post '/annotations/:katagami', to: 'annotations#create'
-  post '/annotations/recommend', to: 'annotations#create_with_recommend'
   # Label
   get '/labels/target/:katagami/:num', to: 'labels#target'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   # Annotation
   post '/annotations/add_has_labels', to: 'annotations#add_has_labels'
   post '/annotations/:katagami', to: 'annotations#create'
+  post '/annotations/recommend', to: 'annotations#create_with_recommend'
   # Label
   get '/labels/target/:katagami/:num', to: 'labels#target'
 end

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -57,7 +57,7 @@ export default () => {
           <Box className={classes.root}>
             <Switch>
               <Route
-                path="/auth/:authorization"
+                path="/auth/:authorization/:canRecommend"
                 render={({ match }) => (
                   <AuthPage
                     {...{

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -36,6 +36,14 @@ export default () => {
     redirectToWelcome()
   }
 
+  const handleDoRecommendAnnotation = () => {
+    window.location.href = 'ant/recommend/2'
+  }
+
+  const handleCancelRecommend = () => {
+    removeCookie('canRecommend', { path: '/' })
+  }
+
   const PrivateRoute = ({ path, component }) => {
     const [cookies] = useCookies(['auth', 'canRecommend'])
     if (cookies.auth) {
@@ -46,6 +54,8 @@ export default () => {
             component({
               auth: cookies.auth,
               canRecommend: cookies.canRecommend === '1',
+              handleCancelRecommend,
+              handleDoRecommendAnnotation,
               ...match.params,
             })
           }

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -17,14 +17,17 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default () => {
-  const [cookies, setCookie, removeCookie] = useCookies(['auth'])
+  const [cookies, setCookie, removeCookie] = useCookies([
+    'auth',
+    'canRecommend',
+  ])
   const classes = useStyles()
 
-  const handleSignIn = auth => {
+  const handleSignIn = (auth, canRecommend) => {
     if (!cookies.auth) {
-      let expires = new Date()
-      expires.setDate(expires.getDate() + 1)
-      setCookie('auth', auth, { path: '/', maxAge: 3600 * 20 })
+      const age = 3600 * 20
+      setCookie('auth', auth, { path: '/', maxAge: age })
+      setCookie('canRecommend', canRecommend, { path: '/', maxAge: age })
     }
   }
 
@@ -34,13 +37,17 @@ export default () => {
   }
 
   const PrivateRoute = ({ path, component }) => {
-    const [cookies] = useCookies(['auth'])
+    const [cookies] = useCookies(['auth', 'canRecommend'])
     if (cookies.auth) {
       return (
         <Route
           path={path}
           render={({ match }) =>
-            component({ auth: cookies.auth, ...match.params })
+            component({
+              auth: cookies.auth,
+              canRecommend: cookies.canRecommend === '1',
+              ...match.params,
+            })
           }
         />
       )

--- a/front/src/components/lv3/Header.js
+++ b/front/src/components/lv3/Header.js
@@ -34,7 +34,7 @@ export default props => {
             )}
           </Grid>
           <Grid item xs={1}>
-            <UserMenu handleSignOut={handleSignOut} />
+            {!isAnnotationPage && <UserMenu handleSignOut={handleSignOut} />}
           </Grid>
         </Grid>
       </Toolbar>

--- a/front/src/components/lv3/UserDetail.js
+++ b/front/src/components/lv3/UserDetail.js
@@ -6,9 +6,7 @@ import { zeroPaddingOf } from 'libs/format'
 import StatusPieChart from 'components/lv2/StatusPieChart'
 
 const useStyles = makeStyles(theme => ({
-  detail: {
-    marginBottom: 40,
-  },
+  detail: { marginBottom: 40 },
 }))
 
 export default props => {
@@ -23,7 +21,7 @@ export default props => {
       setIsLoaging(false)
     }
     fetchUser({ ...{ auth, userId, handleGetUser } })
-  }, [userId])
+  }, [userId, auth])
 
   if (isLoading) return <Typography>Loading...</Typography>
 

--- a/front/src/components/lv4/AnnotationTemplate.js
+++ b/front/src/components/lv4/AnnotationTemplate.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { createAnnotation, fetchLabels, postHasLabels } from 'libs/api'
 import { Grid, Button, Typography } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
@@ -25,7 +26,7 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-export default props => {
+const AnnotationTemplate = props => {
   const { auth, katagamiId, num } = props
   const zeroPaddingId = zeroPaddingOf(katagamiId, 6)
   const classes = useStyles()
@@ -244,3 +245,12 @@ export default props => {
     </Container>
   )
 }
+// auth, katagamiId, num,
+AnnotationTemplate.propTypes = {
+  auth: PropTypes.string.isRequired,
+  katagamiId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    .isRequired,
+  num: PropTypes.number.isRequired,
+}
+
+export default AnnotationTemplate

--- a/front/src/components/lv4/AnnotationTemplate.js
+++ b/front/src/components/lv4/AnnotationTemplate.js
@@ -123,7 +123,7 @@ export default props => {
       katagamiId,
       handleCreateAnnotation,
     })
-  }, [auth, num])
+  }, [auth, num, katagamiId])
 
   // to fetch labels
   useEffect(() => {

--- a/front/src/components/lv4/AnnotationTemplate.js
+++ b/front/src/components/lv4/AnnotationTemplate.js
@@ -152,7 +152,11 @@ export default props => {
 
   return (
     <Container>
-      <HeadLine>型紙 id : {zeroPaddingId}</HeadLine>
+      <HeadLine>
+        {katagamiId === 'recommend'
+          ? 'おすすめの型紙'
+          : `型紙 id : ${zeroPaddingId}`}
+      </HeadLine>
       <DivisionSelect
         {...{
           division,

--- a/front/src/components/lv4/TopTemplate.js
+++ b/front/src/components/lv4/TopTemplate.js
@@ -1,22 +1,20 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { useCookies } from 'react-cookie'
 import Container from 'components/lv1/Container'
 import KatagamiList from 'components/lv3/KatagamiList'
 import HeadLine from 'components/lv1/HeadLine'
 import Modal from 'components/lv2/Modal'
 
 const TopTemplate = props => {
-  const { canRecommend } = props
+  const {
+    canRecommend,
+    handleDoRecommendAnnotation,
+    handleCancelRecommend,
+  } = props
   const [modalIsOpen, setModalIsOpen] = useState(true)
-  const [cookies, setCookie, removeCookie] = useCookies(['canRecommend'])
 
-  const handleDoRecommendAnnotation = () => {
-    window.location.href = 'ant/recommend/2'
-  }
-
-  const handleCancelRecommend = () => {
-    removeCookie('canRecommend', { path: '/' })
+  const handleCancel = () => {
+    handleCancelRecommend()
     setModalIsOpen(false)
   }
 
@@ -26,12 +24,12 @@ const TopTemplate = props => {
       <KatagamiList {...props} />
       <Modal
         isOpen={modalIsOpen && canRecommend}
-        title="オススメの型紙をアノテーションしますか？"
+        title="おすすめの型紙をアノテーションしますか？"
         text="あなたの進捗を確認したうえで, 先にやったほうが良い型紙をチョイスします."
         yesText="はい"
         noText="いいえ"
         handleAnswerYes={handleDoRecommendAnnotation}
-        handleAnswerNo={handleCancelRecommend}
+        handleAnswerNo={handleCancel}
       />
     </Container>
   )
@@ -39,7 +37,9 @@ const TopTemplate = props => {
 
 TopTemplate.propTypes = {
   auth: PropTypes.string.isRequired,
-  canRecommend: PropTypes.string,
+  canRecommend: PropTypes.string.isRequired,
+  handleDoRecommendAnnotation: PropTypes.func.isRequired,
+  handleCancelRecommend: PropTypes.func.isRequired,
 }
 
 export default TopTemplate

--- a/front/src/components/lv4/TopTemplate.js
+++ b/front/src/components/lv4/TopTemplate.js
@@ -1,15 +1,45 @@
-import React from 'react'
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { useCookies } from 'react-cookie'
 import Container from 'components/lv1/Container'
 import KatagamiList from 'components/lv3/KatagamiList'
 import HeadLine from 'components/lv1/HeadLine'
+import Modal from 'components/lv2/Modal'
 
-export default props => {
-  const { auth } = props
+const TopTemplate = props => {
+  const { canRecommend } = props
+  const [modalIsOpen, setModalIsOpen] = useState(true)
+  const [cookies, setCookie, removeCookie] = useCookies(['canRecommend'])
+
+  const handleDoRecommendAnnotation = () => {
+    window.location.href = 'ant/recommend/2'
+  }
+
+  const handleCancelRecommend = () => {
+    removeCookie('canRecommend', { path: '/' })
+    setModalIsOpen(false)
+  }
 
   return (
     <Container>
       <HeadLine>型紙一覧</HeadLine>
-      <KatagamiList auth={auth} />
+      <KatagamiList {...props} />
+      <Modal
+        isOpen={modalIsOpen && canRecommend}
+        title="オススメの型紙をアノテーションしますか？"
+        text="あなたの進捗を確認したうえで, 先にやったほうが良い型紙をチョイスします."
+        yesText="はい"
+        noText="いいえ"
+        handleAnswerYes={handleDoRecommendAnnotation}
+        handleAnswerNo={handleCancelRecommend}
+      />
     </Container>
   )
 }
+
+TopTemplate.propTypes = {
+  auth: PropTypes.string.isRequired,
+  canRecommend: PropTypes.string,
+}
+
+export default TopTemplate

--- a/front/src/pages/AuthPage.js
+++ b/front/src/pages/AuthPage.js
@@ -2,16 +2,14 @@ import React from 'react'
 import { useHistory, Redirect } from 'react-router-dom'
 
 export default props => {
-  const { authorization, handleSignIn, auth, canRecommend } = props
+  const { authorization, canRecommend, handleSignIn, auth } = props
   const history = useHistory()
-
-  console.log(canRecommend)
 
   if (auth) {
     history.replace({ pathname: '/' })
   } else {
     history.push('/')
-    handleSignIn(authorization)
+    handleSignIn(authorization, canRecommend)
   }
 
   return <Redirect to={{ pathname: '/' }} />

--- a/front/src/pages/AuthPage.js
+++ b/front/src/pages/AuthPage.js
@@ -2,8 +2,10 @@ import React from 'react'
 import { useHistory, Redirect } from 'react-router-dom'
 
 export default props => {
-  const { authorization, handleSignIn, auth } = props
+  const { authorization, handleSignIn, auth, canRecommend } = props
   const history = useHistory()
+
+  console.log(canRecommend)
 
   if (auth) {
     history.replace({ pathname: '/' })


### PR DESCRIPTION
## 🍔 やったこと
### front
- おすすめ機能が使える => オールDONEではない状態を`cookies.canRecommend`として保存.
- トップページに, おすすめアノテーションへの導線のあるモーダルを設置.
- 他調整
### API
- 上記の機能実装のために`User`のインスタンスメソッドを追加
  - 冗長な書き方をしているかもしれない
- サインイン時の url にレコメンド可能かどうかを追加
<br />

## 🍣 できるようになったこと
- 自分で表から画像を選ばずに, おすすめアノテーションを実行できる.

![200202-recommend](https://user-images.githubusercontent.com/39250854/73596746-77f9db00-4568-11ea-9c87-cbbb813b17e4.gif)

<br />

## 🍕 やってないこと
### front
- 現状いいえを明示的に押すまでモーダルが出続けるのでうるさいかも
### API
- モデル内の冗長性排除
<br />
