### PR TITLE
HeadLine他にアイコン追加, アノテーション画面のHeadLine削除

### DIFF
--- a/front/src/components/lv1/HeadLine.js
+++ b/front/src/components/lv1/HeadLine.js
@@ -1,18 +1,35 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/styles'
 import { Typography } from '@material-ui/core'
 
 const useStyles = makeStyles(theme => ({
   root: { marginBottom: 40 },
+  icon: { margin: '8px 8px 0 0' },
+  inner: {
+    display: 'flex',
+    alignItems: 'center',
+  },
 }))
 
-export default props => {
+const HeadLine = props => {
+  const { title, Icon } = props
   const classes = useStyles()
 
   return (
     <div className={classes.root}>
-      <Typography variant="h1">{props.children}</Typography>
+      <Typography variant="h1" className={classes.inner}>
+        <span className={classes.icon}>{Icon}</span>
+        {title}
+      </Typography>
       <hr />
     </div>
   )
 }
+
+HeadLine.propTypes = {
+  title: PropTypes.string.isRequired,
+  Icon: PropTypes.func,
+}
+
+export default HeadLine

--- a/front/src/components/lv2/UserList.js
+++ b/front/src/components/lv2/UserList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/styles'
 import { Typography, Paper } from '@material-ui/core'
+import { Group } from '@material-ui/icons'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -18,6 +19,11 @@ const useStyles = makeStyles(theme => ({
       color: theme.palette.primary.main,
     },
   },
+  title: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  icon: { margin: '4px 2px 0 0' },
 }))
 
 export default props => {
@@ -31,7 +37,12 @@ export default props => {
 
   return (
     <Paper className={classes.root}>
-      <Typography>ラベル付けしたユーザー</Typography>
+      <Typography className={classes.title}>
+        <span className={classes.icon}>
+          <Group />
+        </span>
+        ラベル付けしたユーザー
+      </Typography>
       {isActive ? (
         <ul>
           {users.map(user => {

--- a/front/src/components/lv3/UserDetail.js
+++ b/front/src/components/lv3/UserDetail.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react'
-import { fetchUser } from 'libs/api'
 import { Typography, makeStyles } from '@material-ui/core'
-import HeadLine from 'components/lv1/HeadLine'
+import { AccountBox } from '@material-ui/icons'
+import { fetchUser } from 'libs/api'
 import { zeroPaddingOf } from 'libs/format'
+import HeadLine from 'components/lv1/HeadLine'
 import StatusPieChart from 'components/lv2/StatusPieChart'
 
 const useStyles = makeStyles(theme => ({
@@ -27,7 +28,10 @@ export default props => {
 
   return (
     <div>
-      <HeadLine>{`ユーザー id : ${zeroPaddingOf(detail.id, 4)}`}</HeadLine>
+      <HeadLine
+        Icon={<AccountBox fontSize="large" />}
+        title={`user - ${zeroPaddingOf(detail.id, 4)}`}
+      />
       <div className={classes.detail}>
         <Typography variant="h2">登録情報</Typography>
         <Typography>{`メールアドレス : ${detail.email}`}</Typography>

--- a/front/src/components/lv4/AnnotationTemplate.js
+++ b/front/src/components/lv4/AnnotationTemplate.js
@@ -1,14 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Grid, Button, Typography } from '@material-ui/core'
-import { Wallpaper } from '@material-ui/icons'
 import { makeStyles } from '@material-ui/styles'
 import { createAnnotation, fetchLabels, postHasLabels } from 'libs/api'
 import { initAllTiles } from 'libs/tile'
 import { hasLabelsForPost, zeroPaddingOf } from 'libs/format'
 import { MAX_DIVISION } from 'datas/tile'
 import Container from 'components/lv1/Container'
-import HeadLine from 'components/lv1/HeadLine'
 import LoadingModal from 'components/lv1/LoadingModal'
 import DivisionSelect from 'components/lv1/DivisionSelect'
 import Modal from 'components/lv2/Modal'
@@ -29,7 +27,6 @@ const useStyles = makeStyles(theme => ({
 
 const AnnotationTemplate = props => {
   const { auth, katagamiId, num } = props
-  const zeroPaddingId = zeroPaddingOf(katagamiId, 6)
   const classes = useStyles()
 
   const [annotation, setAnnotation] = useState(null)
@@ -154,14 +151,6 @@ const AnnotationTemplate = props => {
 
   return (
     <Container>
-      <HeadLine
-        Icon={<Wallpaper fontSize="large" />}
-        title={
-          katagamiId === 'recommend'
-            ? 'recommend katagami'
-            : `katagami - ${zeroPaddingId}`
-        }
-      />
       <DivisionSelect
         {...{
           division,

--- a/front/src/components/lv4/AnnotationTemplate.js
+++ b/front/src/components/lv4/AnnotationTemplate.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { createAnnotation, fetchLabels, postHasLabels } from 'libs/api'
 import { Grid, Button, Typography } from '@material-ui/core'
+import { Wallpaper } from '@material-ui/icons'
 import { makeStyles } from '@material-ui/styles'
+import { createAnnotation, fetchLabels, postHasLabels } from 'libs/api'
 import { initAllTiles } from 'libs/tile'
 import { hasLabelsForPost, zeroPaddingOf } from 'libs/format'
 import { MAX_DIVISION } from 'datas/tile'
@@ -153,11 +154,14 @@ const AnnotationTemplate = props => {
 
   return (
     <Container>
-      <HeadLine>
-        {katagamiId === 'recommend'
-          ? 'おすすめの型紙'
-          : `型紙 id : ${zeroPaddingId}`}
-      </HeadLine>
+      <HeadLine
+        Icon={<Wallpaper fontSize="large" />}
+        title={
+          katagamiId === 'recommend'
+            ? 'recommend katagami'
+            : `katagami - ${zeroPaddingId}`
+        }
+      />
       <DivisionSelect
         {...{
           division,

--- a/front/src/components/lv4/ResultTemplate.js
+++ b/front/src/components/lv4/ResultTemplate.js
@@ -89,7 +89,7 @@ export default props => {
     <Container>
       <HeadLine
         Icon={<Wallpaper fontSize="large" />}
-        title={`katagami - ${zeroPaddingId}`}
+        title={`Result (katagami - ${zeroPaddingId})`}
       />
       <DivisionSelect
         {...{

--- a/front/src/components/lv4/ResultTemplate.js
+++ b/front/src/components/lv4/ResultTemplate.js
@@ -1,14 +1,15 @@
 import React, { useState, useEffect } from 'react'
 import { Grid } from '@material-ui/core'
+import { Wallpaper } from '@material-ui/icons'
 import { fetchKatagamiResult } from 'libs/api'
 import { zeroPaddingOf, convertBoolToNumOfTiles } from 'libs/format'
+import { MAX_DIVISION } from 'datas/tile'
 import Container from 'components/lv1/Container'
 import HeadLine from 'components/lv1/HeadLine'
 import LoadingModal from 'components/lv1/LoadingModal'
 import DivisionSelect from 'components/lv1/DivisionSelect'
 import KatagamiImage from 'components/lv3/KatagamiImage'
 import ResultDetail from 'components/lv3/ResultDetail'
-import { MAX_DIVISION } from 'datas/tile'
 
 export default props => {
   const { auth, katagamiId } = props
@@ -86,7 +87,10 @@ export default props => {
     />
   ) : (
     <Container>
-      <HeadLine>型紙 id : {zeroPaddingId}</HeadLine>
+      <HeadLine
+        Icon={<Wallpaper fontSize="large" />}
+        title={`katagami - ${zeroPaddingId}`}
+      />
       <DivisionSelect
         {...{
           division,

--- a/front/src/components/lv4/TopTemplate.js
+++ b/front/src/components/lv4/TopTemplate.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import { PhotoLibrary } from '@material-ui/icons'
 import Container from 'components/lv1/Container'
-import KatagamiList from 'components/lv3/KatagamiList'
 import HeadLine from 'components/lv1/HeadLine'
 import Modal from 'components/lv2/Modal'
+import KatagamiList from 'components/lv3/KatagamiList'
 
 const TopTemplate = props => {
   const {
@@ -20,7 +21,7 @@ const TopTemplate = props => {
 
   return (
     <Container>
-      <HeadLine>型紙一覧</HeadLine>
+      <HeadLine Icon={<PhotoLibrary fontSize="large" />} title="型紙一覧" />
       <KatagamiList {...props} />
       <Modal
         isOpen={modalIsOpen && canRecommend}


### PR DESCRIPTION
 ## 🍔 やったこと
### front
- `HeadLine`コンポーネントに`Icon`を渡すように修正
- アノテーションページのヘッダーを削除
  - ヘッダーにアノテーション中の文言出してるし, 
- アイコン追加に伴う文言修正
  - 数字とアルファベットに統一したほうがすっきりした.
無駄なスクロールが必要でストレスがありそうなので.
<br />

## 🍣 できるようになったこと
見た目が変わった.

- ヘッダー達
<img width="490" alt="スクリーンショット 2020-02-02 12 35 46" src="https://user-images.githubusercontent.com/39250854/73602564-8a503500-45b9-11ea-9b19-54da6103498f.png">

<img width="490" alt="スクリーンショット 2020-02-02 12 35 39" src="https://user-images.githubusercontent.com/39250854/73602573-a94ec700-45b9-11ea-9429-13685d9827e4.png">

<img width="507" alt="スクリーンショット 2020-02-02 12 36 02" src="https://user-images.githubusercontent.com/39250854/73602567-963bf700-45b9-11ea-92cb-6f46766b53a4.png">

- 結果ページ
<img width="507" alt="スクリーンショット 2020-02-02 12 36 17" src="https://user-images.githubusercontent.com/39250854/73602566-920fd980-45b9-11ea-9cfb-7e13527a4837.png">

- アノテーションページ

<img width="1437" alt="スクリーンショット 2020-02-02 12 36 41" src="https://user-images.githubusercontent.com/39250854/73602578-c4213b80-45b9-11ea-9a9a-cec348d641e6.png">

<br />

## 🍕 やってないこと
### front
- ホバーでサムネ表示
### API
- サムネ用に`Katagami`の仕様を変更
<br />
