### PR TITLE
productionに上げる(2)前の最終確認

### DIFF
--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -60,6 +60,7 @@ class Katagami < ApplicationRecord
       }
     end
 
+    # アップロードされた型紙の場所(AWS S3)
     def s3_bucket
       Aws::S3::Resource.new(
         region: 'ap-northeast-1',
@@ -68,25 +69,27 @@ class Katagami < ApplicationRecord
       ).bucket('katagami-ant')
     end
 
+    # 認証済みurlを最新にする
     def refresh_url
       find_each { |k| k.presigned_url }
     end
 
+    # dbとs3の差分を読み込む
     def fetch_from_s3_new_files
-      s3_katagamis = Katagami.s3_bucket.objects.to_a
-      db_katagamis_size = Katagami.count
-      new_katagamis = s3_katagamis[db_katagamis_size..-1]
+      s3_katagamis = s3_bucket.objects.sort_by { |item| item.last_modified }.to_a
+      new_katagamis = s3_katagamis[count..-1]
 
       if new_katagamis.size > 0
         fetch_from_s3 new_katagamis
       end
     end
 
-    def fetch_from_s3_files(bucket_objects=s3_bucket.objects)
-      Katagami.transaction do
+    # s3の全データを読み込む
+    def fetch_from_s3(bucket_objects=s3_bucket.objects)
+      transaction do
         bucket_objects.each do |item|
           item_url = item.presigned_url(:get, expires_in: 60 * 65)
-          katagami = Katagami.new(
+          katagami = new(
             name: item.key,
             cw_obj: open(item_url),
             s3_url: item_url,
@@ -137,7 +140,6 @@ class Katagami < ApplicationRecord
   end
 
   # S3バケットに対して認証済みurlを取得
-  # デフォルトの有効期限が1時間なので, それに対応してfetchさせる.
   def presigned_url
     Rails.cache.fetch('katagami-' + id.to_s) do
       target = Katagami.s3_bucket.objects.select { |object| object.key === name }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,25 +1,15 @@
-require 'aws-sdk'
-
-Katagami.transaction do
-  Katagami.s3_bucket.objects.each do |item|
-    item_url = item.presigned_url(:get, expires_in: 60 * 65)
-    katagami = Katagami.new(
-      name: item.key,
-      cw_obj: open(item_url),
-      s3_url: item_url,
-    )
-    katagami.save!
-  end
-end
+Katagami.fetch_from_s3_files
 
 label_names = [
   'kasuri',   'kiku', 'ume',   'hishi',     'sakura',
   'karakusa', 'chou', 'matsu', 'kamenokou', 'asanoha'
 ]
 
-Label.transaction do
-  label_names.each do |name|
-    label = Label.new(name: name)
-    label.save!
+if (label_names.size > Label.count)
+  Label.transaction do
+    label_names.each do |name|
+      label = Label.new(name: name)
+      label.save!
+    end
   end
 end

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -90,7 +90,7 @@ export default () => {
                 component={AnnotationPage}
               />
               <PrivateRoute
-                path="/results/:katagamiId"
+                path="/results/:katagamiId/:wrappedId"
                 component={ResultPage}
               />
               <PrivateRoute path="/users/:userId/" component={UserPage} />

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -90,7 +90,7 @@ export default () => {
                 component={AnnotationPage}
               />
               <PrivateRoute
-                path="/results/:katagamiId/:wrappedId"
+                path="/results/:katagamiId/:fixedId"
                 component={ResultPage}
               />
               <PrivateRoute path="/users/:userId/" component={UserPage} />

--- a/front/src/components/lv1/SortingSelect.js
+++ b/front/src/components/lv1/SortingSelect.js
@@ -42,8 +42,8 @@ export default props => {
           <MenuItem value="">
             <em>指定無し</em>
           </MenuItem>
-          <MenuItem value="2">ユーザー数が少ない順</MenuItem>
-          <MenuItem value="3">達成度が低い順</MenuItem>
+          <MenuItem value="3">ユーザー数が少ない順</MenuItem>
+          <MenuItem value="4">達成度が低い順</MenuItem>
         </Select>
       </FormControl>
     </div>

--- a/front/src/components/lv1/Tile.js
+++ b/front/src/components/lv1/Tile.js
@@ -1,12 +1,18 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/styles'
 import { Grid } from '@material-ui/core'
 import { grey } from '@material-ui/core/colors'
 
 const useStyles = makeStyles(theme => ({
-  root: { border: '1px solid' },
-  selected: { backgroundColor: 'rgba(133, 97, 197, 0.7)' },
+  selected: {
+    backgroundColor: props =>
+      props.stay && props.isSelected
+        ? 'rgba(133, 97, 197, 0.7)'
+        : 'rgba(0, 121, 107, 0.7)',
+  },
   tile: {
+    pointerEvents: props => (props.stay && !props.isSelected ? 'none' : ''),
     color: grey[50],
     border: '1px solid',
     padding: '2px 4px',
@@ -14,9 +20,34 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-export default props => {
-  const { number, square, isSelected, handleToggleTile, isResultPage } = props
-  const classes = useStyles()
+const Tile = props => {
+  const {
+    number,
+    square,
+    isSelected,
+    handleToggleTile,
+    isResultPage,
+    stay,
+    setStay,
+  } = props
+  const classes = useStyles({ stay, isSelected })
+
+  if (isResultPage) {
+    const handleToggleStay = () => {
+      setStay(!stay)
+    }
+    return (
+      <Grid
+        item
+        xs={12 / square}
+        className={
+          isSelected ? classes.tile + ' ' + classes.selected : classes.tile
+        }
+        onMouseEnter={() => handleToggleTile(number)}
+        onClick={handleToggleStay}
+      />
+    )
+  }
 
   return (
     <Grid
@@ -25,16 +56,19 @@ export default props => {
       className={
         isSelected ? classes.tile + ' ' + classes.selected : classes.tile
       }
-      onMouseOver={() => {
-        if (isResultPage) {
-          handleToggleTile(number)
-        }
-      }}
-      onClick={() => {
-        if (!isResultPage) {
-          handleToggleTile(number)
-        }
-      }}
+      onClick={() => handleToggleTile(number)}
     />
   )
 }
+
+Tile.propTypes = {
+  number: PropTypes.number.isRequired,
+  square: PropTypes.number.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  handleToggleTile: PropTypes.func.isRequired,
+  isResultPage: PropTypes.bool.isRequired,
+  stay: PropTypes.bool,
+  setStay: PropTypes.func,
+}
+
+export default Tile

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -38,13 +38,13 @@ const KatagamiListBody = props => {
       </TableCell>
     )
 
-  const wrappedId = i => i + 1 + page * rowsPerPage
+  const fixedId = i => i + 1 + page * rowsPerPage
 
   return (
     <TableBody>
       {katagamis.map((katagami, i) => (
         <TableRow key={katagami.id} className={classes.tableRow}>
-          <TableCell align="right">{wrappedId(i)}</TableCell>
+          <TableCell align="right">{fixedId(i)}</TableCell>
           <ToggledThumbnail
             katagami={katagami}
             selectedId={selectedId}
@@ -68,9 +68,7 @@ const KatagamiListBody = props => {
             <IconButton
               className={classes.button}
               onClick={() =>
-                (window.location.href = `/results/${katagami.id}/${wrappedId(
-                  i
-                )}`)
+                (window.location.href = `/results/${katagami.id}/${fixedId(i)}`)
               }
             >
               <Equalizer />

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import { TableRow, TableCell, TableBody, IconButton } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
 import { Create, Equalizer } from '@material-ui/icons'
@@ -18,8 +19,8 @@ const useStyles = makeStyles(theme => ({
   button: { padding: 4 },
 }))
 
-export default props => {
-  const { katagamis, emptyRows, handleSelectId } = props
+const KatagamiListBody = props => {
+  const { page, rowsPerPage, katagamis, emptyRows, handleSelectId } = props
   const [selectedId, setSelectedId] = useState(0)
   const classes = useStyles()
 
@@ -37,11 +38,13 @@ export default props => {
       </TableCell>
     )
 
+  const wrappedId = i => i + 1 + page * rowsPerPage
+
   return (
     <TableBody>
-      {katagamis.map(katagami => (
+      {katagamis.map((katagami, i) => (
         <TableRow key={katagami.id} className={classes.tableRow}>
-          <TableCell align="right">{katagami.id}</TableCell>
+          <TableCell align="right">{wrappedId(i)}</TableCell>
           <ToggledThumbnail
             katagami={katagami}
             selectedId={selectedId}
@@ -79,3 +82,20 @@ export default props => {
     </TableBody>
   )
 }
+
+KatagamiListBody.propTypes = {
+  page: PropTypes.number.isRequired,
+  rowsPerPage: PropTypes.number.isRequired,
+  katagamis: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+      status: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+  emptyRows: PropTypes.number,
+  handleSelectId: PropTypes.func.isRequired,
+}
+
+export default KatagamiListBody

--- a/front/src/components/lv2/KatagamiListBody.js
+++ b/front/src/components/lv2/KatagamiListBody.js
@@ -67,7 +67,11 @@ const KatagamiListBody = props => {
           <TableCell align="center">
             <IconButton
               className={classes.button}
-              onClick={() => (window.location.href = `/results/${katagami.id}`)}
+              onClick={() =>
+                (window.location.href = `/results/${katagami.id}/${wrappedId(
+                  i
+                )}`)
+              }
             >
               <Equalizer />
             </IconButton>

--- a/front/src/components/lv2/ResultGraph.js
+++ b/front/src/components/lv2/ResultGraph.js
@@ -15,7 +15,7 @@ export default props => {
         {data.map((entry, index) => (
           <Cell
             cursor="pointer"
-            fill={index === activeIndex ? '#007769' : '#9a67ea'}
+            fill={index === activeIndex ? '#9a67ea' : '#007769'}
             key={index}
           />
         ))}

--- a/front/src/components/lv2/UserList.js
+++ b/front/src/components/lv2/UserList.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
     padding: 16,
     margin: '0 0 16px 60px',
     border: props =>
-      props.isActive ? `2px solid ${theme.palette.primary.light}` : 'none',
+      props.isActive ? `2px solid ${theme.palette.secondary.light}` : 'none',
   },
   user: {
     cursor: 'pointer',

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
   katagami: {
     backgroundImage: props => `url(${props.katagamiUrl})`,
     backgroundSize: 'cover',
-    border: props => (props.tileIsSelectable ? '2px solid #673ab7' : 'none'),
+    border: props => (props.tileIsSelectable ? '2px solid #00796B' : 'none'),
     width: props => `${props.fixedWidth}px`,
     height: props => `${props.fixedHeight}px`,
   },

--- a/front/src/components/lv3/KatagamiImage.js
+++ b/front/src/components/lv3/KatagamiImage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { makeStyles } from '@material-ui/styles'
 import { Grid } from '@material-ui/core'
 import Tile from 'components/lv1/Tile'
@@ -47,8 +47,7 @@ export default props => {
     tileIsSelectable,
     savedTilesAreNotZero,
   })
-
-  console.log(isResultPage)
+  const [stay, setStay] = useState(false)
 
   const TilesOnKatagami = () => {
     const labels = []
@@ -61,6 +60,8 @@ export default props => {
           isSelected={selectedTiles[i - 1]}
           handleToggleTile={handleToggleTile}
           isResultPage={isResultPage}
+          stay={stay}
+          setStay={setStay}
         />
       )
     }

--- a/front/src/components/lv3/KatagamiList.js
+++ b/front/src/components/lv3/KatagamiList.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import {
   Table,
   TableHead,
@@ -38,7 +39,7 @@ const useStyles = makeStyles(theme => ({
   footer: { marginTop: theme.spacing(20) },
 }))
 
-export default props => {
+const KatagamiList = props => {
   const { auth, ownedUser } = props
   const [katagamis, setKatagamis] = useState([])
   const [count, setCount] = useState(0)
@@ -141,6 +142,8 @@ export default props => {
         </TableHead>
         <KatagamiListBody
           {...{
+            page,
+            rowsPerPage,
             katagamis,
             emptyRows,
             handleSelectId,
@@ -177,3 +180,10 @@ export default props => {
     </div>
   )
 }
+
+KatagamiList.propTypes = {
+  auth: PropTypes.string.isRequired,
+  ownedUser: PropTypes.number,
+}
+
+export default KatagamiList

--- a/front/src/components/lv3/UserDetail.js
+++ b/front/src/components/lv3/UserDetail.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Typography, makeStyles } from '@material-ui/core'
 import { AccountBox } from '@material-ui/icons'
 import { fetchUser } from 'libs/api'
-import { zeroPaddingOf } from 'libs/format'
+import { zeroPaddingOf, fixedProdId } from 'libs/format'
 import HeadLine from 'components/lv1/HeadLine'
 import StatusPieChart from 'components/lv2/StatusPieChart'
 
@@ -30,7 +30,12 @@ export default props => {
     <div>
       <HeadLine
         Icon={<AccountBox fontSize="large" />}
-        title={`user - ${zeroPaddingOf(detail.id, 4)}`}
+        title={`user - ${zeroPaddingOf(
+          process.env.NODE_ENV === 'production'
+            ? fixedProdId(detail.id)
+            : fixedProdId(detail.id),
+          4
+        )}`}
       />
       <div className={classes.detail}>
         <Typography variant="h2">登録情報</Typography>

--- a/front/src/components/lv4/ResultTemplate.js
+++ b/front/src/components/lv4/ResultTemplate.js
@@ -136,8 +136,8 @@ const ResultTempalte = props => {
 
 ResultTempalte.propTypes = {
   auth: PropTypes.string.isRequired,
-  katagamiId: PropTypes.number.isRequired,
-  fixedId: PropTypes.number.isRequired,
+  katagamiId: PropTypes.string.isRequired,
+  fixedId: PropTypes.string.isRequired,
 }
 
 export default ResultTempalte

--- a/front/src/components/lv4/ResultTemplate.js
+++ b/front/src/components/lv4/ResultTemplate.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { Grid } from '@material-ui/core'
 import { Wallpaper } from '@material-ui/icons'
 import { fetchKatagamiResult } from 'libs/api'
@@ -11,9 +12,9 @@ import DivisionSelect from 'components/lv1/DivisionSelect'
 import KatagamiImage from 'components/lv3/KatagamiImage'
 import ResultDetail from 'components/lv3/ResultDetail'
 
-export default props => {
-  const { auth, katagamiId } = props
-  const zeroPaddingId = zeroPaddingOf(katagamiId, 6)
+const ResultTempalte = props => {
+  const { auth, katagamiId, wrappedId } = props
+  const zeroPaddingId = zeroPaddingOf(wrappedId, 6)
 
   const [katagamiUrl, setKatagamiUrl] = useState('')
   const [katagamiWidth, setKatagamiWidth] = useState(0)
@@ -132,3 +133,11 @@ export default props => {
     </Container>
   )
 }
+
+ResultTempalte.propTypes = {
+  auth: PropTypes.string.isRequired,
+  katagamiId: PropTypes.number.isRequired,
+  wrappedId: PropTypes.number.isRequired,
+}
+
+export default ResultTempalte

--- a/front/src/components/lv4/ResultTemplate.js
+++ b/front/src/components/lv4/ResultTemplate.js
@@ -13,8 +13,8 @@ import KatagamiImage from 'components/lv3/KatagamiImage'
 import ResultDetail from 'components/lv3/ResultDetail'
 
 const ResultTempalte = props => {
-  const { auth, katagamiId, wrappedId } = props
-  const zeroPaddingId = zeroPaddingOf(wrappedId, 6)
+  const { auth, katagamiId, fixedId } = props
+  const zeroPaddingId = zeroPaddingOf(fixedId, 6)
 
   const [katagamiUrl, setKatagamiUrl] = useState('')
   const [katagamiWidth, setKatagamiWidth] = useState(0)
@@ -137,7 +137,7 @@ const ResultTempalte = props => {
 ResultTempalte.propTypes = {
   auth: PropTypes.string.isRequired,
   katagamiId: PropTypes.number.isRequired,
-  wrappedId: PropTypes.number.isRequired,
+  fixedId: PropTypes.number.isRequired,
 }
 
 export default ResultTempalte

--- a/front/src/libs/format.js
+++ b/front/src/libs/format.js
@@ -82,3 +82,6 @@ export const graphDataOf = (hasLabel, wholeLabels) => {
     }
   })
 }
+
+// production環境だとidが10インクリメントなので, 表示だけ1インクリメントに対応させる.
+export const fixedProdId = id => (id === 1 ? id : id / 10)


### PR DESCRIPTION
## 🍔 やったこと
### front
- ブランチ切らずに進めていた以下の作業の修正
  - 結果画面で`Tile`の`onClick`アクションを`onMouseEnter`に変更していた. スムーズに動けていいやと思いきや選択状態が必要になったので, 新たに`stay`stateを作って対応.
  - `palette.primary`, `palette.secondary`の使用を↑に対応して修正.
- productionでのDB仕様に表示だけ対応
  - 10インクリメント => 1インクリメント
- #42 で`katagamis`の形式変更に伴う`SortingSelect`の`value`を変更.
### API
- 型紙画像をs3から取得する処理をseedからモデルに移植.
- 新たに追加した画像のみをdbに反映させる`Katagami.fetch_from_s3_new_files`を作成.
<br />

## 🍣 できるようになったこと
- 結果画面のタイル選択がマウスオーバーでできる.
- クリックするとグラフをクリックしてユーザー一覧を確認できる.

![200203-nurunuru](https://user-images.githubusercontent.com/39250854/73611366-7392f800-4624-11ea-88c0-70f6a93f3e52.gif)

<br />

## 🍕 やってないこと
### front
- とはいえ, 結果画面はまだまだ改善の余地がある気がする.
### API
- s3から取得した画像の向きが変わってる...なんでや.
<br />
