### PR TITLE
型紙画像の認証済みurlを更新するタスクを作成 + productionでの修正

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -45,12 +45,14 @@ class Annotation < ApplicationRecord
   # 自身に紐付くHasLabel生成
   def add(has_label)
     _has_label = has_label.split(' ').map { |n| n.to_i }
+    label_id = _has_label.shift
+
+    if ENV['RAILS_ENV'] == 'production' && label_id != '1'
+      label_id = label_id * 10 + 1
+    end
+
     label = Label.find(_has_label.shift) # has_labelの先頭はlabel_id
     division = _has_label.shift # その次はdivision
-
-    if ENV['RAILS_ENV'] == 'production'
-      label = label == 1 ? 1 : label * 10 + 1
-    end
 
     _has_label.each {|position|
       HasLabel.create(

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -48,6 +48,10 @@ class Annotation < ApplicationRecord
     label = Label.find(_has_label.shift) # has_labelの先頭はlabel_id
     division = _has_label.shift # その次はdivision
 
+    if ENV['RAILS_ENV'] == 'production'
+      label = label == 1 ? 1 : label * 10 + 1
+    end
+
     _has_label.each {|position|
       HasLabel.create(
         annotation: self, katagami: katagami, label: label, division: division, position: position

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -15,7 +15,7 @@ class Annotation < ApplicationRecord
     
     {
       id: annotation.id,
-      katagami_url: katagami.presigned_url,
+      katagami_url: katagami.s3_url,
       katagami_width: katagami.width,
       katagami_height: katagami.height
     }

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -45,13 +45,13 @@ class Annotation < ApplicationRecord
   # 自身に紐付くHasLabel生成
   def add(has_label)
     _has_label = has_label.split(' ').map { |n| n.to_i }
-    label_id = _has_label.shift
+    label_id = _has_label.shift # has_labelの先頭はlabel_id
 
     if ENV['RAILS_ENV'] == 'production' && label_id != '1'
       label_id = label_id * 10 + 1
     end
 
-    label = Label.find(_has_label.shift) # has_labelの先頭はlabel_id
+    label = Label.find(label_id) 
     division = _has_label.shift # その次はdivision
 
     _has_label.each {|position|

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -70,8 +70,8 @@ class Katagami < ApplicationRecord
     end
 
     # 認証済みurlを最新にする
-    def refresh_url
-      find_each { |k| k.presigned_url }
+    def refresh_all_presigned_urls
+      find_each { |k| k.get_presigned_url }
     end
 
     # dbとs3の差分を読み込む
@@ -140,12 +140,9 @@ class Katagami < ApplicationRecord
   end
 
   # S3バケットに対して認証済みurlを取得
-  def presigned_url
-    Rails.cache.fetch('katagami-' + id.to_s) do
-      target = Katagami.s3_bucket.objects.select { |object| object.key === name }
-      update(s3_url: target[0].presigned_url(:get, expires_in: 60 * 60 * 30))
-      s3_url
-    end
+  def get_presigned_url
+    target = Katagami.s3_bucket.objects.select { |object| object.key === name }
+    update(s3_url: target[0].presigned_url(:get, expires_in: 60 * 60 * 30))
   end
 end
 

--- a/app/models/katagami.rb
+++ b/app/models/katagami.rb
@@ -88,7 +88,7 @@ class Katagami < ApplicationRecord
     def fetch_from_s3(bucket_objects=s3_bucket.objects)
       transaction do
         bucket_objects.each do |item|
-          item_url = item.presigned_url(:get, expires_in: 60 * 65)
+          item_url = item.presigned_url(:get, expires_in: 60 * 60 * 30)
           katagami = new(
             name: item.key,
             cw_obj: open(item_url),
@@ -143,7 +143,7 @@ class Katagami < ApplicationRecord
   def presigned_url
     Rails.cache.fetch('katagami-' + id.to_s) do
       target = Katagami.s3_bucket.objects.select { |object| object.key === name }
-      update(s3_url: target[0].presigned_url(:get, expires_in: 60 * 60 * 24))
+      update(s3_url: target[0].presigned_url(:get, expires_in: 60 * 60 * 30))
       s3_url
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module KatagamiAnt
     config.api_only = true
 
     # setting for usinge OmuniAuth into API
-    config.cache_store = :redis_store, 'redis://redis:6379/0', { expires_in: 1.hour }
+    config.cache_store = :redis_store, 'redis://redis:6379/0', { expires_in: 1.day }
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CacheStore
     config.middleware.use ActionDispatch::Flash

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_store, ENV['REDISCLOUD_URL'], { expires_in: 1.hour }
+  config.cache_store = :redis_store, ENV['REDISCLOUD_URL'], { expires_in: 1.day }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/front/src/libs/format.js
+++ b/front/src/libs/format.js
@@ -84,4 +84,4 @@ export const graphDataOf = (hasLabel, wholeLabels) => {
 }
 
 // production環境だとidが10インクリメントなので, 表示だけ1インクリメントに対応させる.
-export const fixedProdId = id => (id === 1 ? id : id / 10)
+export const fixedProdId = id => (id === 1 ? id : Math.floor(id / 10) + 1)

--- a/lib/tasks/refresh_presigned_url.rake
+++ b/lib/tasks/refresh_presigned_url.rake
@@ -1,0 +1,7 @@
+desc 'Refresh all katagami.presined_urls'
+
+task refresh_katagami: :environment do
+  p 'Refreshing presigned_urls ...'
+  Katagmai.refresh_all_presigned_urls
+  p 'done.'
+end

--- a/lib/tasks/refresh_presigned_url.rake
+++ b/lib/tasks/refresh_presigned_url.rake
@@ -1,7 +1,7 @@
 desc 'Refresh all katagami.presined_urls'
 
 task refresh_katagami: :environment do
-  p 'Refreshing presigned_urls ...'
-  Katagmai.refresh_all_presigned_urls
-  p 'done.'
+  puts 'Refreshing presigned_urls ...'
+  Katagami.refresh_all_presigned_urls
+  puts 'done.'
 end


### PR DESCRIPTION
## 🍔 やったこと
### front
- clearDB問題(10インクリメント)対策の修正.
### API
- `cache_store`の期限を1時間から1日に変更.
- `katagami.presigned_url`の期限も1日+ちょっとに変更.
- rakeタスクを作成して, herokuのスケジューラー登録で定期的に更新できるようにした.
<br />

## 🍣 できるようになったこと
- 認証済みurlの更新が定期的に実行される.
<br />

## 🍕 やってないこと
<br />
